### PR TITLE
feat: add ability to send SMS to multiple phone numbers with same or different carriers

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,8 +86,8 @@ Here is a list of variables that you can use to customize your newly copied `.en
 | `NVIDIA_SESSION_TTL` | The time in milliseconds to keep the cart active while using `nvidia-api` | Default: `60000` |
 | `OPEN_BROWSER` | Toggle for whether or not the browser should open when item is found | Default: `true` |
 | `PAGE_TIMEOUT` | Navigation Timeout in milliseconds | `0` for infinite, default: `30000` |
-| `PHONE_NUMBER` | 10 digit phone number | E.g.: `1234567890`, email configuration required |
-| `PHONE_CARRIER` | [Supported carriers](#supported-carriers) for SMS | Email configuration required |
+| `PHONE_NUMBER` | 10 digit phone numbers | E.g.: `1234567890` or `1234567890,0987654321,1235556666`, email configuration required |
+| `PHONE_CARRIER` | [Supported carriers](#supported-carriers) for SMS | Email configuration required. Either one carrier or the carriers in same order as phone numbers |
 | `PLAY_SOUND` | Play this sound notification if a card is found | Relative path accepted, valid formats: wav, mp3, flac, E.g.: `path/to/notification.wav`, [free sounds available](https://notificationsounds.com/) |
 | `PUSHBULLET` | PushBullet API key | Generate at https://www.pushbullet.com/#settings/account | |
 | `PUSHOVER_TOKEN` | Pushover access token | Generate at https://pushover.net/apps/build | |

--- a/src/config.ts
+++ b/src/config.ts
@@ -87,8 +87,8 @@ const notifications = {
 			['virgin', 'vmobl.com'],
 			['virgin-ca', 'vmobile.ca']
 		]),
-		carrier: envOrString(process.env.PHONE_CARRIER),
-		number: envOrString(process.env.PHONE_NUMBER)
+		carrier: envOrArray(process.env.PHONE_CARRIER),
+		number: envOrArray(process.env.PHONE_NUMBER)
 	},
 	playSound: envOrString(process.env.PLAY_SOUND),
 	pushbullet: envOrString(process.env.PUSHBULLET),


### PR DESCRIPTION
<!-- Please use Conventional Commits to label your title -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/ -->
<!-- Example: feat: allow provided config object to extend other configs  -->

### Description

Resolves #273 

You can now list multiple phone number in .env.  If only one carrier is listed, it'll use that one carrier for all phone numbers.  If more than one carrier is listed, the list of carriers has to be in the same order as the phone numbers listed.

### Testing

did a test with one number and one carrier, it passed

did a test with two numbers and one carrier, it passed
![two_sms_sent-10-04 075044](https://user-images.githubusercontent.com/422996/95019225-b67cf380-0629-11eb-8a63-93044816037f.png)

did a test with two numbers and two carriers(the carriers were the same, but listed twice), it passed

did a test with three numbers, with spaces after the commans, and one carrier, it passed
![test_with_three_numbers_and_spaces](https://user-images.githubusercontent.com/422996/95019143-5e45f180-0629-11eb-84c2-615ef97e45a3.png)

![test_with_three_numbers_and_spaces-2](https://user-images.githubusercontent.com/422996/95019196-99e0bb80-0629-11eb-9129-c907a2a3fc23.png)

did a test with three numbers, with spaces after the commas, and three carriers, with spaces after the commas, it passed
![test_with_three_numbers_and_spaces_and_three_carriers_with_spaces](https://user-images.githubusercontent.com/422996/95019203-a107c980-0629-11eb-9fc7-ab1a6454adc8.png)


did a test for the warning if it's not one carrier and the number or carriers doesn't match the number of phone numbers.
![warning_if_carrier_is_not_one_or_same_number_or_phone_numbers](https://user-images.githubusercontent.com/422996/95019248-d6141c00-0629-11eb-93d3-f41f4db6477d.png)

did a test of just running the app for a few minutes, no issues.
