### PR TITLE
feat(store): add zen 3 to german stores

### DIFF
--- a/src/store/model/alternate.ts
+++ b/src/store/model/alternate.ts
@@ -315,6 +315,30 @@ export const Alternate: Store = {
 			model: 'trinity',
 			series: '3090',
 			url: 'https://www.alternate.de/product/1672611'
+		},
+		{
+			brand: 'amd',
+			model: '5600x',
+			series: 'ryzen5600',
+			url: 'https://www.alternate.de/product/1685588'
+		},
+		{
+			brand: 'amd',
+			model: '5800x',
+			series: 'ryzen5800',
+			url: 'https://www.alternate.de/product/1685585'
+		},
+		{
+			brand: 'amd',
+			model: '5900x',
+			series: 'ryzen5900',
+			url: 'https://www.alternate.de/product/1685590'
+		},
+		{
+			brand: 'amd',
+			model: '5950x',
+			series: 'ryzen5950',
+			url: 'https://www.alternate.de/product/1685584'
 		}
 	],
 	name: 'alternate'

--- a/src/store/model/amazon-de.ts
+++ b/src/store/model/amazon-de.ts
@@ -352,6 +352,30 @@ export const AmazonDe: Store = {
 			model: 'xlr8 rgb',
 			series: '3070',
 			url: 'https://www.amazon.de/dp/B08HBJB7YD'
+		},
+		{
+			brand: 'amd',
+			model: '5600x',
+			series: 'ryzen5600',
+			url: 'https://www.amazon.de/dp/B08166SLDF'
+		},
+		{
+			brand: 'amd',
+			model: '5800x',
+			series: 'ryzen5800',
+			url: 'https://www.amazon.de/dp/B0815XFSGK'
+		},
+		{
+			brand: 'amd',
+			model: '5900x',
+			series: 'ryzen5900',
+			url: 'https://www.amazon.de/dp/B08164VTWH'
+		},
+		{
+			brand: 'amd',
+			model: '5950x',
+			series: 'ryzen5950',
+			url: 'https://www.amazon.de/dp/B0815Y8J9N'
 		}
 	],
 	name: 'amazon-de'

--- a/src/store/model/caseking.ts
+++ b/src/store/model/caseking.ts
@@ -268,6 +268,30 @@ export const Caseking: Store = {
 			model: 'trinity',
 			series: '3090',
 			url: 'https://www.caseking.de/zotac-gaming-geforce-rtx-3090-trinity-24576-mb-gddr6x-gczt-162.html'
+		},
+		{
+			brand: 'amd',
+			model: '5600x',
+			series: 'ryzen5600',
+			url: 'https://www.caseking.de/amd-ryzen-5-5600x-3-7-ghz-vermeer-am4-mit-amd-wraith-stealth-kuehler-hpam-202.html'
+		},
+		{
+			brand: 'amd',
+			model: '5800x',
+			series: 'ryzen5800',
+			url: 'https://www.caseking.de/amd-ryzen-7-5800x-3-8-ghz-vermeer-am4-boxed-ohne-kuehler-hpam-203.html'
+		},
+		{
+			brand: 'amd',
+			model: '5900x',
+			series: 'ryzen5900',
+			url: 'https://www.caseking.de/amd-ryzen-9-5900x-3-7-ghz-vermeer-am4-boxed-ohne-kuehler-hpam-204.html'
+		},
+		{
+			brand: 'amd',
+			model: '5950x',
+			series: 'ryzen5950',
+			url: 'https://www.caseking.de/amd-ryzen-9-5950x-3-4-ghz-vermeer-am4-boxed-ohne-kuehler-hpam-205.html'
 		}
 	],
 	name: 'caseking'

--- a/src/store/model/computeruniverse.ts
+++ b/src/store/model/computeruniverse.ts
@@ -449,6 +449,30 @@ export const Computeruniverse: Store = {
 			model: 'trinity',
 			series: '3090',
 			url: 'https://www.computeruniverse.net/de/zotac-gaming-geforce-rtx-3090-trinity-24-gb-enthusiast-grafikkarte'
+		},
+		{
+			brand: 'amd',
+			model: '5600x',
+			series: 'ryzen5600',
+			url: 'https://www.computeruniverse.net/de/amd-ryzen-5-5600x-boxed-mit-wraith-stealth-kuehler'
+		},
+		{
+			brand: 'amd',
+			model: '5800x',
+			series: 'ryzen5800',
+			url: 'https://www.computeruniverse.net/de/amd-ryzen-7-5800x-box-ohne-kuehler'
+		},
+		{
+			brand: 'amd',
+			model: '5900x',
+			series: 'ryzen5900',
+			url: 'https://www.computeruniverse.net/de/amd-ryzen-9-5900x-box-ohne-kuehler'
+		},
+		{
+			brand: 'amd',
+			model: '5950x',
+			series: 'ryzen5950',
+			url: 'https://www.computeruniverse.net/de/amd-ryzen-9-5950x-box-ohne-kuehler'
 		}
 	],
 	name: 'computeruniverse'

--- a/src/store/model/cyberport.ts
+++ b/src/store/model/cyberport.ts
@@ -93,6 +93,30 @@ export const Cyberport: Store = {
 			model: 'trinity oc',
 			series: '3080',
 			url: 'https://www.cyberport.de?DEEP=2E13-1H7'
+		},
+		{
+			brand: 'amd',
+			model: '5600x',
+			series: 'ryzen5600',
+			url: 'https://www.cyberport.de?DEEP=2001-71p'
+		},
+		{
+			brand: 'amd',
+			model: '5800x',
+			series: 'ryzen5800',
+			url: 'https://www.cyberport.de/?DEEP=2001-71n'
+		},
+		{
+			brand: 'amd',
+			model: '5900x',
+			series: 'ryzen5900',
+			url: 'https://www.cyberport.de?DEEP=2001-71m'
+		},
+		{
+			brand: 'amd',
+			model: '5950x',
+			series: 'ryzen5950',
+			url: 'https://www.cyberport.de?DEEP=2001-71l'
 		}
 	],
 	name: 'cyberport'

--- a/src/store/model/mindfactory.ts
+++ b/src/store/model/mindfactory.ts
@@ -81,6 +81,18 @@ export const Mindfactory: Store = {
 			model: 'gaming pro',
 			series: '3090',
 			url: 'https://www.mindfactory.de/product_info.php/24GB-Palit-GeForce-RTX-3090-GamingPro-DDR6--Retail-_1377233.html'
+		},
+		{
+			brand: 'amd',
+			model: '5600x',
+			series: 'ryzen5600',
+			url: 'https://www.mindfactory.de/product_info.php/AMD-Ryzen-5-5600X-6x-3-70GHz-So-AM4-BOX_1380726.html'
+		},
+		{
+			brand: 'amd',
+			model: '5800x',
+			series: 'ryzen5800',
+			url: 'https://www.mindfactory.de/product_info.php/AMD-Ryzen-7-5800X-8x-3-80GHz-So-AM4-WOF_1380727.html'
 		}
 	],
 	name: 'mindfactory'

--- a/src/store/model/notebooksbilliger.ts
+++ b/src/store/model/notebooksbilliger.ts
@@ -219,6 +219,30 @@ export const Notebooksbilliger: Store = {
 			model: 'trinity',
 			series: '3090',
 			url: 'https://www.notebooksbilliger.de/zotac+gaming+geforce+rtx+3090+trinity+24gb+gddr6x+grafikkarte+677550'
+		},
+		{
+			brand: 'amd',
+			model: '5600x',
+			series: 'ryzen5600',
+			url: 'https://www.notebooksbilliger.de/amd+ryzen+5+5600x+cpu+684022'
+		},
+		{
+			brand: 'amd',
+			model: '5800x',
+			series: 'ryzen5800',
+			url: 'https://www.notebooksbilliger.de/amd+ryzen+ryzen+7+5800x+cpu+684018'
+		},
+		{
+			brand: 'amd',
+			model: '5900x',
+			series: 'ryzen5900',
+			url: 'https://www.notebooksbilliger.de/amd+ryzen+9+5900x+cpu+684032'
+		},
+		{
+			brand: 'amd',
+			model: '5950x',
+			series: 'ryzen5950',
+			url: 'https://www.notebooksbilliger.de/amd+ryzen+9+5950x+cpu+684033'
 		}
 	],
 	name: 'notebooksbilliger'

--- a/src/store/model/proshop-de.ts
+++ b/src/store/model/proshop-de.ts
@@ -251,6 +251,30 @@ export const ProshopDE: Store = {
 			model: 'gaming x trio',
 			series: '3090',
 			url: 'https://www.proshop.de/2876881'
+		},
+		{
+			brand: 'amd',
+			model: '5600x',
+			series: 'ryzen5600',
+			url: 'https://www.proshop.de/2884168'
+		},
+		{
+			brand: 'amd',
+			model: '5800x',
+			series: 'ryzen5800',
+			url: 'https://www.proshop.de/2884171'
+		},
+		{
+			brand: 'amd',
+			model: '5900x',
+			series: 'ryzen5900',
+			url: 'https://www.proshop.de/2884173'
+		},
+		{
+			brand: 'amd',
+			model: '5950x',
+			series: 'ryzen5950',
+			url: 'https://www.proshop.de/2884175'
 		}
 	],
 	name: 'proshop-de'


### PR DESCRIPTION
## Description

I added the zen 3 processors to some german stores: alternate, amazon-de, caseking, computeruniverse, cyberport, mindfactory (only 5600x and 5800x, I could not finde the other links), notebooksbilliger, proshop-de .

### Testing

I let the streetmerchant check the stock for the zen 3 processors on these stores and it worked fine.

<img width="805" alt="Screenshot 1" src="https://user-images.githubusercontent.com/2456590/98351220-b3a46280-201c-11eb-9bb3-0e7c2873686f.png">

<img width="805" alt="Screenshot 2" src="https://user-images.githubusercontent.com/2456590/98351232-b901ad00-201c-11eb-81e1-733de6484195.png">
