### PR TITLE
feat(ps5): add console and digital edition

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,9 @@ environment variables are **optional**._
 | Proshop (DK) | `proshop-dk`|
 | Saturn (DE) | `saturn`|
 | Scan (UK) | `scan`|
+| Target | `target`|
 | Very (UK) | `very`|
+| Walmart | `walmart`|
 | Zotac | `zotac`|
 
 <details>
@@ -222,6 +224,7 @@ environment variables are **optional**._
 | `nvidia` | `founders edition` |
 | `palit` | `gamerock oc`, `gaming pro`, `gaming pro oc` |
 | `pny` | `dual fan`, `xlr8`, `xlr8 rgb` |
+| `sony` | `ps5 console`, `ps5 digital` |
 | `zotac` | `amp holo`, `amp extreme holo`, `trinity`, `trinity oc`, `twin edge`, `twin edge oc` |
 
 </details>

--- a/src/config.ts
+++ b/src/config.ts
@@ -255,6 +255,8 @@ const store = {
 			ryzen5800: envOrNumber(process.env.MAX_PRICE_SERIES_RYZEN5800),
 			ryzen5900: envOrNumber(process.env.MAX_PRICE_SERIES_RYZEN5900),
 			ryzen5950: envOrNumber(process.env.MAX_PRICE_SERIES_RYZEN5950),
+			sonyps5c: -1,
+			sonyps5de: -1,
 			'test:series': -1
 		}
 	},
@@ -267,7 +269,7 @@ const store = {
 			series: envOrString(series)
 		};
 	}),
-	showOnlySeries: envOrArray(process.env.SHOW_ONLY_SERIES, ['3070', '3080', '3090', 'ryzen5600', 'ryzen5800', 'ryzen5900', 'ryzen5950']),
+	showOnlySeries: envOrArray(process.env.SHOW_ONLY_SERIES, ['3070', '3080', '3090', 'ryzen5600', 'ryzen5800', 'ryzen5900', 'ryzen5950', 'sonyps5c', 'sonyps5de']),
 	stores: envOrArray(process.env.STORES, ['nvidia']).map(entry => {
 		const [name, minPageSleep, maxPageSleep] = entry.match(/[^:]+/g) ?? [];
 		return {

--- a/src/store/model/amazon.ts
+++ b/src/store/model/amazon.ts
@@ -210,6 +210,20 @@ export const Amazon: Store = {
 			model: '5950x',
 			series: 'ryzen5950',
 			url: 'https://www.amazon.com/dp/product/B0815Y8J9N'
+		},
+		{
+			brand: 'sony',
+			cartUrl: 'https://www.amazon.com/gp/aws/cart/add.html?ASIN.1=B08FC5L3RG&Quantity.1=1',
+			model: 'ps5 console',
+			series: 'sonyps5c',
+			url: 'https://www.amazon.com/dp/B08FC5L3RG'
+		},
+		{
+			brand: 'sony',
+			cartUrl: 'https://www.amazon.com/gp/aws/cart/add.html?ASIN.1=B08FC6MR62&Quantity.1=1',
+			model: 'ps5 digital',
+			series: 'sonyps5de',
+			url: 'https://www.amazon.com/dp/B08FC6MR62'
 		}
 	],
 	name: 'amazon'

--- a/src/store/model/bestbuy.ts
+++ b/src/store/model/bestbuy.ts
@@ -255,6 +255,20 @@ export const BestBuy: Store = {
 			model: '5600x',
 			series: 'ryzen5600',
 			url: 'https://www.bestbuy.com/site/amd-ryzen-5-5600x-4th-gen-6-core-12-threads-unlocked-desktop-processor-with-wraith-stealth-cooler/6438943.p?skuId=6438943&intl=nosplash'
+		},
+		{
+			brand: 'sony',
+			cartUrl: 'https://api.bestbuy.com/click/-/6426149/cart',
+			model: 'ps5 console',
+			series: 'sonyps5c',
+			url: 'https://www.bestbuy.com/site/sony-playstation-5-console/6426149.p?skuId=6426149&intl=nosplash'
+		},
+		{
+			brand: 'sony',
+			cartUrl: 'https://api.bestbuy.com/click/-/6430161/cart',
+			model: 'ps5 digital',
+			series: 'sonyps5de',
+			url: 'https://www.bestbuy.com/site/sony-playstation-5-digital-edition-console/6430161.p?skuId=6430161&intl=nosplash'
 		}
 	],
 	name: 'bestbuy'

--- a/src/store/model/gamestop.ts
+++ b/src/store/model/gamestop.ts
@@ -2,10 +2,16 @@ import {Store} from './store';
 
 export const Gamestop: Store = {
 	labels: {
-		inStock: {
-			container: '.add-to-cart',
-			text: ['add to cart']
-		},
+		inStock: [
+			{
+				container: '.add-to-cart',
+				text: ['add to cart']
+			},
+			{
+				container: '.add-to-cart',
+				text: ['Pre-Order']
+			}
+		],
 		maxPrice: {
 			container: '.primary-details-row .actual-price',
 			euroFormat: false
@@ -27,6 +33,18 @@ export const Gamestop: Store = {
 			model: 'tuf oc',
 			series: '3080',
 			url: 'https://www.gamestop.com/video-games/pc/components/graphics-cards/products/tuf-gaming-geforce-rtx-3080-graphics-card/11109446.html'
+		},
+		{
+			brand: 'sony',
+			model: 'ps5 console',
+			series: 'sonyps5c',
+			url: 'https://www.gamestop.com/video-games/playstation-5/consoles/products/playstation-5/11108140'
+		},
+		{
+			brand: 'sony',
+			model: 'ps5 digital',
+			series: 'sonyps5de',
+			url: 'https://www.gamestop.com/video-games/playstation-5/consoles/products/playstation-5-digital-edition/11108141'
 		}
 	],
 	name: 'gamestop',

--- a/src/store/model/index.ts
+++ b/src/store/model/index.ts
@@ -46,7 +46,9 @@ import {ProshopDK} from './proshop-dk';
 import {Saturn} from './saturn';
 import {Scan} from './scan';
 import {Store} from './store';
+import {Target} from './target';
 import {Very} from './very';
+import {Walmart} from './walmart';
 import {Zotac} from './zotac';
 import {logger} from '../../logger';
 
@@ -97,7 +99,9 @@ export const storeList = new Map([
 	[ProshopDK.name, ProshopDK],
 	[Saturn.name, Saturn],
 	[Scan.name, Scan],
+	[Target.name, Target],
 	[Very.name, Very],
+	[Walmart.name, Walmart],
 	[Zotac.name, Zotac]
 ]);
 

--- a/src/store/model/store.ts
+++ b/src/store/model/store.ts
@@ -10,10 +10,10 @@ export type Pricing = {
 	euroFormat?: boolean;
 };
 
-export type Series = 'test:series' | '3070' | '3080' | '3090' | 'ryzen5950' | 'ryzen5900' | 'ryzen5800' | 'ryzen5600';
+export type Series = 'test:series' | '3070' | '3080' | '3090' | 'ryzen5950' | 'ryzen5900' | 'ryzen5800' | 'ryzen5600' | 'sonyps5c' | 'sonyps5de';
 
 export type Link = {
-	brand: 'test:brand' | 'amd' | 'asus' | 'evga' | 'gainward' | 'gigabyte' | 'inno3d' | 'kfa2' | 'msi' | 'nvidia' | 'palit' | 'pny' | 'zotac';
+	brand: 'test:brand' | 'amd' | 'asus' | 'evga' | 'gainward' | 'gigabyte' | 'inno3d' | 'kfa2' | 'msi' | 'nvidia' | 'palit' | 'pny'| 'sony' | 'zotac';
 	itemNumber?: string;
 	series: Series;
 	model: string;

--- a/src/store/model/target.ts
+++ b/src/store/model/target.ts
@@ -1,0 +1,28 @@
+import {Store} from './store';
+
+export const Target: Store = {
+	labels: {
+		inStock: {
+			container: '[data-test="preorderButton"]',
+			text: ['Preorder now']
+		},
+		maxPrice: {
+			container: '[data-test="product-price"]'
+		}
+	},
+	links: [
+		{
+			brand: 'sony',
+			model: 'ps5 console',
+			series: 'sonyps5c',
+			url: 'https://www.target.com/p/playstation-5-console/-/A-81114595'
+		},
+		{
+			brand: 'sony',
+			model: 'ps5 digital',
+			series: 'sonyps5de',
+			url: 'https://www.target.com/p/playstation-5-digital-edition-console/-/A-81114596'
+		}
+	],
+	name: 'target'
+};

--- a/src/store/model/walmart.ts
+++ b/src/store/model/walmart.ts
@@ -1,0 +1,28 @@
+import {Store} from './store';
+
+export const Walmart: Store = {
+	labels: {
+		inStock: {
+			container: '#ProductPrimaryCTA-cta_add_to_cart_button',
+			text: ['Add to cart']
+		},
+		maxPrice: {
+			container: 'span[class*="price-characteristic"]'
+		}
+	},
+	links: [
+		{
+			brand: 'sony',
+			model: 'ps5 console',
+			series: 'sonyps5c',
+			url: 'https://www.walmart.com/ip/PlayStation5-Console/363472942'
+		},
+		{
+			brand: 'sony',
+			model: 'ps5 digital',
+			series: 'sonyps5de',
+			url: 'https://www.walmart.com/ip/PlayStation5-Console/363472942'
+		}
+	],
+	name: 'walmart'
+};


### PR DESCRIPTION
### Description

- Add PS5 Console and PS5 Digital Edition support
- Add Walmart, Target stores
