### PR TITLE
feat(store): add ps5 to german stores

### DIFF
--- a/src/store/model/alternate.ts
+++ b/src/store/model/alternate.ts
@@ -339,6 +339,18 @@ export const Alternate: Store = {
 			model: '5950x',
 			series: 'ryzen5950',
 			url: 'https://www.alternate.de/product/1685584'
+		},
+		{
+			brand: 'sony',
+			model: 'ps5 console',
+			series: 'sonyps5c',
+			url: 'https://www.alternate.de/product/1651220'
+		},
+		{
+			brand: 'sony',
+			model: 'ps5 digital',
+			series: 'sonyps5de',
+			url: 'https://www.alternate.de/product/1651221'
 		}
 	],
 	name: 'alternate'

--- a/src/store/model/amazon-de.ts
+++ b/src/store/model/amazon-de.ts
@@ -376,6 +376,18 @@ export const AmazonDe: Store = {
 			model: '5950x',
 			series: 'ryzen5950',
 			url: 'https://www.amazon.de/dp/B0815Y8J9N'
+		},
+		{
+			brand: 'sony',
+			model: 'ps5 console',
+			series: 'sonyps5c',
+			url: 'https://www.amazon.de/dp/B08H93ZRK9'
+		},
+		{
+			brand: 'sony',
+			model: 'ps5 digital',
+			series: 'sonyps5de',
+			url: 'https://www.amazon.de/dp/B08H98GVK8'
 		}
 	],
 	name: 'amazon-de'

--- a/src/store/model/mediamarkt.ts
+++ b/src/store/model/mediamarkt.ts
@@ -231,6 +231,18 @@ export const Mediamarkt: Store = {
 			model: 'gaming x trio',
 			series: '3090',
 			url: 'https://www.mediamarkt.de/de/product/-2683226.html'
+		},
+		{
+			brand: 'sony',
+			model: 'ps5 console',
+			series: 'sonyps5c',
+			url: 'https://www.mediamarkt.de/de/product/-2661938.html'
+		},
+		{
+			brand: 'sony',
+			model: 'ps5 digital',
+			series: 'sonyps5de',
+			url: 'https://www.mediamarkt.de/de/product/-2661939.html'
 		}
 	],
 	name: 'mediamarkt'

--- a/src/store/model/saturn.ts
+++ b/src/store/model/saturn.ts
@@ -155,6 +155,18 @@ export const Saturn: Store = {
 			model: 'gaming x trio',
 			series: '3090',
 			url: 'https://www.saturn.de/de/product/-2683226.html'
+		},
+		{
+			brand: 'sony',
+			model: 'ps5 console',
+			series: 'sonyps5c',
+			url: 'https://www.saturn.de/de/product/-2661938.html'
+		},
+		{
+			brand: 'sony',
+			model: 'ps5 digital',
+			series: 'sonyps5de',
+			url: 'https://www.saturn.de/de/product/-2661939.html'
 		}
 	],
 	name: 'saturn'


### PR DESCRIPTION
### Description

I added the PS5 to the German stores alternate, amazon-de, mediamarkt and saturn.

### Testing

Seemed to work fine:

<img width="805" alt="Screenshot 1" src="https://user-images.githubusercontent.com/2456590/98438108-1d3d7300-20e8-11eb-827b-8656f2a18a9d.png">

