### PR TITLE
feat(mindfactory): add ryzen 5900x, 5950x

### DIFF
--- a/src/store/model/mindfactory.ts
+++ b/src/store/model/mindfactory.ts
@@ -93,6 +93,18 @@ export const Mindfactory: Store = {
 			model: '5800x',
 			series: 'ryzen5800',
 			url: 'https://www.mindfactory.de/product_info.php/AMD-Ryzen-7-5800X-8x-3-80GHz-So-AM4-WOF_1380727.html'
+		},
+		{
+			brand: 'amd',
+			model: '5900x',
+			series: 'ryzen5900',
+			url: 'https://www.mindfactory.de/product_info.php/AMD-Ryzen-9-5900X-12x-3-70GHz-So-AM4-WOF_1380728.html'
+		},
+		{
+			brand: 'amd',
+			model: '5950x',
+			series: 'ryzen5950',
+			url: 'https://www.mindfactory.de/product_info.php/AMD-Ryzen-9-5950X-16x-3-40GHz-So-AM4-WOF_1380729.html'
 		}
 	],
 	name: 'mindfactory'


### PR DESCRIPTION
### Description
The two higher tier Ryzen5000 models were missing from the mindfactory.ts file

### Testing
None tbh, however links are the official ones taken from their [Ryzen5000 Series overview / FarCr6 Bundle page](https://www.mindfactory.de/Highlights/AMD_Ryzen_Game_Bundle_FarCry6/Badge/163x80_badge_AMD_Ryzen_Game_Bundle_FarCry6_NEW).

### New dependencies
None