### PR TITLE
feat(store): add `arlt` and `amd-de`

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,10 @@ environment variables are **optional**._
 | Amazon (ES) | `amazon-es`|
 | Amazon (NL) | `amazon-nl`|
 | Amazon (UK) | `amazon-uk`|
+| AMD | `amd`|
+| AMD (DE) | `amd-de`|
 | Aria PC (UK) | `aria`|
+| ARLT (DE) | `arlt`|
 | ASUS | `asus` |
 | ASUS (DE) | `asus-de` |
 | Azerty (NL) | `azerty`|

--- a/src/store/model/amd-de.ts
+++ b/src/store/model/amd-de.ts
@@ -1,0 +1,51 @@
+import {Store} from './store';
+
+export const AMDDe: Store = {
+	labels: {
+		inStock: {
+			container: '.btn-shopping-cart',
+			text: ['add to cart']
+		},
+		maxPrice: {
+			container: '.product-page-description h4',
+			euroFormat: true
+		}
+	},
+	links: [
+		{
+			brand: 'test:brand',
+			model: 'test:model',
+			series: 'test:series',
+			url: 'https://www.amd.com/de/direct-buy/5450881400/de'
+		},
+		{
+			brand: 'amd',
+			cartUrl: 'https://www.amd.com/de/direct-buy/5450881400/de?add-to-cart=true',
+			model: '5950x',
+			series: 'ryzen5950',
+			url: 'https://www.amd.com/de/direct-buy/5450881400/de'
+		},
+		{
+			brand: 'amd',
+			cartUrl: 'https://www.amd.com/de/direct-buy/5450881500/de?add-to-cart=true',
+			model: '5900x',
+			series: 'ryzen5900',
+			url: 'https://www.amd.com/de/direct-buy/5450881500/de'
+		},
+		{
+			brand: 'amd',
+			cartUrl: 'https://www.amd.com/de/direct-buy/5450881600/de?add-to-cart=true',
+			model: '5800x',
+			series: 'ryzen5800',
+			url: 'https://www.amd.com/de/direct-buy/5450881600/de'
+		},
+		{
+			brand: 'amd',
+			cartUrl: 'https://www.amd.com/de/direct-buy/5450881700/de?add-to-cart=true',
+			model: '5600x',
+			series: 'ryzen5600',
+			url: 'https://www.amd.com/de/direct-buy/5450881700/de'
+		}
+	],
+	name: 'amd-de'
+};

--- a/src/store/model/arlt.ts
+++ b/src/store/model/arlt.ts
@@ -1,0 +1,123 @@
+import {Store} from './store';
+
+export const Arlt: Store = {
+	labels: {
+		inStock: {
+			container: '.articleDesc .shippingtext',
+			text: ['auf Lager', 'Lieferzeit 2-3 Werktage', 'Ware im Zulauf']
+		},
+		maxPrice: {
+			container: '.articleprice .price',
+			euroFormat: true
+		},
+		outOfStock: {
+			container: '.articleDesc .shippingtext',
+			text: ['Neuer Artikel in Kürze verfügbar', 'Liefertermin unbekannt']
+		}
+	},
+	links: [
+		{
+			brand: 'test:brand',
+			model: 'test:model',
+			series: 'test:series',
+			url: 'https://www.arlt.com/ASUS-GeForce-GTX1650-Super-TUF-GTX1650S-O4G-GAMING.html'
+		},
+		{
+			brand: 'asus',
+			model: 'dual',
+			series: '3070',
+			url: 'https://www.arlt.com/Gaming/Gaming-Hardware/Grafikkarten/ASUS-Dual-GeForce-RTX-3070.html'
+		},
+		{
+			brand: 'asus',
+			model: 'dual oc',
+			series: '3070',
+			url: 'https://www.arlt.com/Hardware/PC-Komponenten/Grafikkarten/NVIDIA/ASUS-Dual-GeForce-RTX-3070-OC.html'
+		},
+		{
+			brand: 'asus',
+			model: 'tuf oc',
+			series: '3070',
+			url: 'https://www.arlt.com/Gaming/Gaming-Hardware/Grafikkarten/ASUS-TUF-Gaming-GeForce-RTX-3070-OC.html'
+		},
+		{
+			brand: 'asus',
+			model: 'rog strix',
+			series: '3070',
+			url: 'https://www.arlt.com/Hardware/PC-Komponenten/Grafikkarten/NVIDIA/GeForce-RTX/RTX-3070/ASUS-ROG-Strix-GeForce-RTX-3070.html'
+		},
+		{
+			brand: 'msi',
+			model: 'ventus 2x oc',
+			series: '3070',
+			url: 'https://www.arlt.com/Hardware/PC-Komponenten/Grafikkarten/NVIDIA/GeForce-RTX/RTX-3070/MSI-GeForce-RTX-3070-Ventus-2X-OC.html'
+		},
+		{
+			brand: 'gainward',
+			model: 'phoenix',
+			series: '3070',
+			url: 'https://www.arlt.com/Hardware/PC-Komponenten/Grafikkarten/NVIDIA/GeForce-RTX/Gainward-GeForce-RTX-3070-Phoenix.html'
+		},
+		{
+			brand: 'gainward',
+			model: 'phoenix gs',
+			series: '3070',
+			url: 'https://www.arlt.com/Gaming/Gaming-Hardware/Gainward-GeForce-RTX-3070-Phoenix-GS.html'
+		},
+		{
+			brand: 'asus',
+			model: 'tuf oc',
+			series: '3080',
+			url: 'https://www.arlt.com/Hardware/PC-Komponenten/Grafikkarten/ASUS-TUF-Gaming-GeForce-RTX-3080-OC.html'
+		},
+		{
+			brand: 'msi',
+			model: 'ventus 3x oc',
+			series: '3080',
+			url: 'https://www.arlt.com/Hardware/PC-Komponenten/Grafikkarten/NVIDIA/GeForce-RTX/RTX-3080/MSI-GeForce-RTX-3080-Ventus-3X-OC.html'
+		},
+		{
+			brand: 'asus',
+			model: 'tuf oc',
+			series: '3090',
+			url: 'https://www.arlt.com/Hardware/PC-Komponenten/Grafikkarten/NVIDIA/GeForce-RTX/RTX-3090/ASUS-TUF-Gaming-GeForce-RTX-3090-OC.html'
+		},
+		{
+			brand: 'asus',
+			model: 'rog strix oc',
+			series: '3090',
+			url: 'https://www.arlt.com/Hardware/PC-Komponenten/Grafikkarten/NVIDIA/GeForce-RTX/RTX-3090/ASUS-ROG-Strix-GeForce-RTX-3090-OC.html'
+		},
+		{
+			brand: 'gainward',
+			model: 'phoenix gs',
+			series: '3090',
+			url: 'https://www.arlt.com/Gaming/Gaming-Hardware/Gainward-GeForce-RTX-3090-Phoenix-GS.html'
+		},
+		{
+			brand: 'amd',
+			model: '5600x',
+			series: 'ryzen5600',
+			url: 'https://www.arlt.com/Hardware/PC-Komponenten/Prozessoren-arlt/AMD-Ryzen-5-5600X-boxed.html'
+		},
+		{
+			brand: 'amd',
+			model: '5800x',
+			series: 'ryzen5800',
+			url: 'https://www.arlt.com/Hardware/PC-Komponenten/Prozessoren-arlt/AMD-Ryzen-7-5800X-boxed.html'
+		},
+		{
+			brand: 'amd',
+			model: '5900x',
+			series: 'ryzen5900',
+			url: 'https://www.arlt.com/Hardware/PC-Komponenten/Prozessoren-arlt/AMD-Ryzen-9-5900X-boxed.html'
+		},
+		{
+			brand: 'amd',
+			model: '5900x',
+			series: 'ryzen5950',
+			url: 'https://www.arlt.com/Hardware/PC-Komponenten/Prozessoren-arlt/AMD-Ryzen-9-5950X-boxed.html'
+		}
+	],
+	name: 'arlt'
+};

--- a/src/store/model/index.ts
+++ b/src/store/model/index.ts
@@ -1,5 +1,6 @@
 import {config, defaultStoreData} from '../../config';
 import {AMD} from './amd';
+import {AMDDe} from './amd-de';
 import {Adorama} from './adorama';
 import {Alternate} from './alternate';
 import {AlternateNL} from './alternate-nl';
@@ -10,6 +11,7 @@ import {AmazonEs} from './amazon-es';
 import {AmazonNl} from './amazon-nl';
 import {AmazonUk} from './amazon-uk';
 import {Aria} from './aria';
+import {Arlt} from './arlt';
 import {Asus} from './asus';
 import {AsusDe} from './asus-de';
 import {Azerty} from './azerty';
@@ -63,7 +65,9 @@ export const storeList = new Map([
 	[AmazonNl.name, AmazonNl],
 	[AmazonUk.name, AmazonUk],
 	[AMD.name, AMD],
+	[AMDDe.name, AMDDe],
 	[Aria.name, Aria],
+	[Arlt.name, Arlt],
 	[Asus.name, Asus],
 	[AsusDe.name, AsusDe],
 	[Azerty.name, Azerty],


### PR DESCRIPTION
### Description

I have added the store Arlt with some 3070s, 3080s, 3090s and the zen 3 processors. I have also added the german AMD as a store with the zen 3 processors.

### Testing

I tested the status check for Arlt and AMD-de and I tested the price recognition for Arlt with 3 and 4 digit numbers.

<img width="805" alt="screenshot 1" src="https://user-images.githubusercontent.com/2456590/98466023-3409c580-21cd-11eb-9a9f-66dbc0400fe7.png">

<img width="805" alt="screenshot 2" src="https://user-images.githubusercontent.com/2456590/98466029-3bc96a00-21cd-11eb-884f-663c2c75ea22.png">

<img width="805" alt="screenshot 3" src="https://user-images.githubusercontent.com/2456590/98466035-3ff58780-21cd-11eb-9bc5-706624bc79b8.png">

