### PR TITLE
feat(store): add `game` store, add ps5 for uk stores

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ environment variables are **optional**._
 | EVGA | `evga`|
 | EVGA (EU) | `evga-eu`|
 | Galaxus (DE) | `galaxus`|
+| Game (UK) | `game`|
 | Gamestop | `gamestop`|
 | Mediamarkt (DE) | `mediamarkt`|
 | MemoryExpress (CA) | `memoryexpress`|

--- a/src/store/model/amazon-uk.ts
+++ b/src/store/model/amazon-uk.ts
@@ -34,6 +34,20 @@ export const AmazonUk: Store = {
 			model: 'test:model',
 			series: 'test:series',
 			url: 'https://www.amazon.co.uk/dp/B081265T5Z/'
+		},
+		{
+			brand: 'sony',
+			cartUrl: 'https://www.amazon.com/gp/aws/cart/add.html?ASIN.1=B08FC5L3RG&Quantity.1=1',
+			model: 'ps5 console',
+			series: 'sonyps5c',
+			url: 'https://www.amazon.com/dp/B08FC5L3RG'
+		},
+		{
+			brand: 'sony',
+			cartUrl: 'https://www.amazon.com/gp/aws/cart/add.html?ASIN.1=B08H97NYGP&Quantity.1=1',
+			model: 'ps5 digital',
+			series: 'sonyps5de',
+			url: 'https://www.amazon.co.uk/dp/B08H97NYGP/'
 		}
 	],
 	linksBuilder: {

--- a/src/store/model/ebuyer.ts
+++ b/src/store/model/ebuyer.ts
@@ -22,6 +22,18 @@ export const Ebuyer: Store = {
 			model: 'test:model',
 			series: 'test:series',
 			url: 'https://www.ebuyer.com/874209-gigabyte-geforce-rtx-2060-windforce-6gb-oc-graphics-card-gv-n2060wf2oc-6gd-v2'
+		},
+		{
+			brand: 'sony',
+			model: 'ps5 console',
+			series: 'sonyps5c',
+			url: 'https://www.ebuyer.com/1125329-sony-playstation-5-console-cfi-1015a'
+		},
+		{
+			brand: 'sony',
+			model: 'ps5 digital',
+			series: 'sonyps5de',
+			url: 'https://www.ebuyer.com/1125332-sony-playstation-5-digital-edition-cfi-1015b'
 		}
 	],
 	linksBuilder: {

--- a/src/store/model/game.ts
+++ b/src/store/model/game.ts
@@ -1,0 +1,33 @@
+import {Store} from './store';
+
+export const Game: Store = {
+	labels: {
+		inStock: {
+			container: '.buyingOptions',
+			text: ['Pre-order Now', 'Buy New']
+		},
+		maxPrice: {
+			container: '.buyingOptions .btnPrice',
+			euroFormat: false
+		},
+		outOfStock: {
+			container: '.buyingOptions',
+			text: ['out of stock']
+		}
+	},
+	links: [
+		{
+			brand: 'sony',
+			model: 'ps5 console',
+			series: 'sonyps5c',
+			url: 'https://www.game.co.uk/en/playstation-5-console-2826338'
+		},
+		{
+			brand: 'sony',
+			model: 'ps5 digital',
+			series: 'sonyps5de',
+			url: 'https://www.game.co.uk/en/playstation-5-digital-edition-2826341'
+		}
+	],
+	name: 'game'
+};

--- a/src/store/model/game.ts
+++ b/src/store/model/game.ts
@@ -17,6 +17,12 @@ export const Game: Store = {
 	},
 	links: [
 		{
+			brand: 'test:brand',
+			model: 'test:model',
+			series: 'test:series',
+			url: 'https://www.game.co.uk/en/ea-sports-fifa-21-500gb-ps4-bundle-2832947'
+		},
+		{
 			brand: 'sony',
 			model: 'ps5 console',
 			series: 'sonyps5c',

--- a/src/store/model/index.ts
+++ b/src/store/model/index.ts
@@ -30,6 +30,7 @@ import {Ebuyer} from './ebuyer';
 import {Evga} from './evga';
 import {EvgaEu} from './evga-eu';
 import {Galaxus} from './galaxus';
+import {Game} from './game';
 import {Gamestop} from './gamestop';
 import {Mediamarkt} from './mediamarkt';
 import {MemoryExpress} from './memoryexpress';
@@ -88,6 +89,7 @@ export const storeList = new Map([
 	[Evga.name, Evga],
 	[EvgaEu.name, EvgaEu],
 	[Galaxus.name, Galaxus],
+	[Game.name, Game],
 	[Gamestop.name, Gamestop],
 	[Mediamarkt.name, Mediamarkt],
 	[MemoryExpress.name, MemoryExpress],

--- a/src/store/model/scan.ts
+++ b/src/store/model/scan.ts
@@ -27,6 +27,18 @@ export const Scan: Store = {
 			model: 'test:model',
 			series: 'test:series',
 			url: 'https://www.scan.co.uk/products/msi-geforce-rtx-2060-ventus-xs-oc-6gb-gddr6-vr-ready-graphics-card-1920-core-1710mhz-boost'
+		},
+		{
+			brand: 'sony',
+			model: 'ps5 console',
+			series: 'sonyps5c',
+			url: 'https://www.scan.co.uk/products/playstation-5-console'
+		},
+		{
+			brand: 'sony',
+			model: 'ps5 digital',
+			series: 'sonyps5de',
+			url: 'https://www.scan.co.uk/products/playstation-5-digital-edition'
 		}
 	],
 	linksBuilder: {


### PR DESCRIPTION
### Description

Adds support for the following:
- Add new store: game (Game UK)
- Add PS5 links for amazon-uk, ebuyer, scan, game

### Testing

- All added new links are currently working and reporting back correctly
- Game UK store tested with item conditions: Buy New, Pre-order, out of stock. 