### PR TITLE
docs: add zen3 filter to `SHOW_ONLY_SERIES`

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ environment variables are **optional**._
 | `NVIDIA_SESSION_TTL` | The time in milliseconds to keep the cart active while using `nvidia-api` | Default: `60000` |
 | `SHOW_ONLY_BRANDS` | Filter to show specified brands | Comma separated, e.g.: `evga,zotac` |
 | `SHOW_ONLY_MODELS` | Filter to show specified models | Both supported formats are comma separated <br/><br/>1. Standard  E.g.: `founders edition,rog strix` <br/><br/> 2. Advanced E.g: `MODEL:SERIES`, E.g: `founders edition:3090,rog strix` |
-| `SHOW_ONLY_SERIES` | Filter to show specified series | Comma separated, e.g.: `3080` |
+| `SHOW_ONLY_SERIES` | Filter to show specified series | Comma separated, e.g.: `3080,ryzen5900` |
 | `STORES` | [Supported stores](#supported-stores) you want to be scraped | Both supported formats are comma separated <br/><br/>1. Standard  E.g.: `"nvidia"` <br/><br/> 2. Advanced E.g: `STORE:PAGE_SLEEP_MIN:PAGE_SLEEP_MAX`, E.g: `nvidia:10000:30000` <br/><br/>Default: `nvidia` |
 
 <details>


### PR DESCRIPTION
docs: Added an example of how to add a zen3 cpu to the filter to the readme.

<!-- Please use Conventional Commits to label your title -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/ -->
<!-- Example: feat: allow provided config object to extend other configs  -->

### Description

I noticed that I got the syntax for adding a Ryzen cpu to the filter wrong and thought the readme could use a subtle update to show how to do it. 

### Testing

N/A
