### PR TITLE
feat(store): Added CanadaComputers Ryzen & EVGA

### DIFF
--- a/src/store/model/canadacomputers.ts
+++ b/src/store/model/canadacomputers.ts
@@ -1,0 +1,108 @@
+import {Store} from './store';
+
+export const CanadaComputers: Store = {
+	labels: {
+		maxPrice: {
+			container: 'NEEDS TO BE FILLED IN',
+			euroFormat: false
+		},
+		outOfStock: {
+			container: 'NEEDS TO BE FILLED IN',
+			text: ['Not Available Online']
+		}
+	},
+	links: [
+		{
+			brand: 'test:brand',
+			model: 'test:model',
+			series: 'test:series',
+			url: 'https://www.canadacomputers.com/product_info.php?cPath=43_557_559&item_id=151558'
+		},
+		{
+			brand: 'amd',
+			model: '5950x',
+			series: 'ryzen5950',
+			url: 'https://www.canadacomputers.com/product_info.php?cPath=4_64&item_id=183427'
+		},
+		{
+			brand: 'amd',
+			model: '5900x',
+			series: 'ryzen5900',
+			url: 'https://www.canadacomputers.com/product_info.php?cPath=4_64&item_id=183430'
+		},
+		{
+			brand: 'amd',
+			model: '5800x',
+			series: 'ryzen5800',
+			url: 'https://www.canadacomputers.com/product_info.php?cPath=4_64&item_id=183431'
+		},
+		{
+			brand: 'amd',
+			model: '5600x',
+			series: 'ryzen5600',
+			url: 'https://www.canadacomputers.com/product_info.php?cPath=4_64&item_id=183432'
+		},
+		{
+			brand: 'evga',
+			model: 'xc3 black',
+			series: '3070',
+			url: 'https://www.canadacomputers.com/product_info.php?cPath=43_557_559&item_id=183500'
+		},
+		{
+			brand: 'evga',
+			model: 'xc3 ultra',
+			series: '3070',
+			url: 'https://www.canadacomputers.com/product_info.php?cPath=43_557_559&item_id=183499'
+		},
+		{
+			brand: 'evga',
+			model: 'ftw3 ultra',
+			series: '3070',
+			url: 'https://www.canadacomputers.com/product_info.php?cPath=43_557_559&item_id=183498'
+		},
+		{
+			brand: 'evga',
+			model: 'xc3 black',
+			series: '3080',
+			url: 'https://www.canadacomputers.com/product_info.php?cPath=43_557_559&item_id=181797'
+		},
+		{
+			brand: 'evga',
+			model: 'ftw3 ultra',
+			series: '3080',
+			url: 'https://www.canadacomputers.com/product_info.php?cPath=43_557_559&item_id=181376'
+		},
+		{
+			brand: 'evga',
+			model: 'xc3',
+			series: '3080',
+			url: 'https://www.canadacomputers.com/product_info.php?cPath=43_557_559&item_id=181798'
+		},
+		{
+			brand: 'evga',
+			model: 'xc3 ultra',
+			series: '3080',
+			url: 'https://www.canadacomputers.com/product_info.php?cPath=43_557_559&item_id=181375'
+		},
+		{
+			brand: 'evga',
+			model: 'ftw3 ultra',
+			series: '3090',
+			url: 'https://www.canadacomputers.com/product_info.php?cPath=43_557_559&item_id=181854'
+		},
+		{
+			brand: 'evga',
+			model: 'xc3',
+			series: '3090',
+			url: 'https://www.canadacomputers.com/product_info.php?cPath=43_557_559&item_id=181852'
+		},
+		{
+			brand: 'evga',
+			model: 'xc3 ultra',
+			series: '3090',
+			url: 'https://www.canadacomputers.com/product_info.php?cPath=43_557_559&item_id=181853'
+		}
+	],
+	name: 'canadacomputers',
+	waitUntil: 'domcontentloaded'
+};

--- a/src/store/model/index.ts
+++ b/src/store/model/index.ts
@@ -17,6 +17,7 @@ import {BAndH} from './bandh';
 import {BestBuy} from './bestbuy';
 import {BestBuyCa} from './bestbuy-ca';
 import {Box} from './box';
+import {CanadaComputers} from './canadacomputers';
 import {Caseking} from './caseking';
 import {Ccl} from './ccl';
 import {Computeruniverse} from './computeruniverse';
@@ -71,6 +72,7 @@ export const storeList = new Map([
 	[BestBuy.name, BestBuy],
 	[BestBuyCa.name, BestBuyCa],
 	[Box.name, Box],
+	[CanadaComputers.name, CanadaComputers],
 	[Caseking.name, Caseking],
 	[Ccl.name, Ccl],
 	[Computeruniverse.name, Computeruniverse],


### PR DESCRIPTION
### Description

Fixes #730  

This adds support for CanadaComputers, for both Ryzen CPUs and EVGA 3000-series GPUs.

**NOTE: This is a WIP and should not be merged into master with first commit! `labels.maxPrice` and `labels.outOfStock` need to be added.**

