### PR TITLE
feat(discord): add cart link to embed

### DIFF
--- a/src/notification/discord.ts
+++ b/src/notification/discord.ts
@@ -15,7 +15,9 @@ export function sendDiscordMessage(link: Link, store: Store) {
 			try {
 				const embed = new MessageBuilder();
 				embed.setTitle('Stock Notification');
-				embed.addField('URL', link.cartUrl ? link.cartUrl : link.url, true);
+				if (link.cartUrl)
+					embed.addField('Add To Cart Link', link.cartUrl, true);
+				embed.addField('Product Page', link.url, true);
 				embed.addField('Store', store.name, true);
 				embed.addField('Brand', link.brand, true);
 				embed.addField('Series', link.series, true);


### PR DESCRIPTION
### Description

Due to popular demand, add both the product page link and ATC link to the discord embed when a product is in stock.

![image](https://user-images.githubusercontent.com/18109616/98771969-a2a87800-23b3-11eb-8543-0f6bb410c7a2.png)

### Testing

Tested with the amazon test card when a ATC link is and isn't defined.

