### PR TITLE
fix(walmart): ps5 digital url

### DIFF
--- a/src/store/model/walmart.ts
+++ b/src/store/model/walmart.ts
@@ -21,7 +21,7 @@ export const Walmart: Store = {
 			brand: 'sony',
 			model: 'ps5 digital',
 			series: 'sonyps5de',
-			url: 'https://www.walmart.com/ip/PlayStation5-Console/363472942'
+			url: 'https://www.walmart.com/ip/Sony-PlayStation-5-Digital-Edition/493824815'
 		},
 		{
 			brand: 'microsoft',

--- a/src/store/model/walmart.ts
+++ b/src/store/model/walmart.ts
@@ -21,7 +21,8 @@ export const Walmart: Store = {
 			brand: 'sony',
 			model: 'ps5 digital',
 			series: 'sonyps5de',
-			url: 'https://www.walmart.com/ip/Sony-PlayStation-5-Digital-Edition/493824815'
+			url:
+				'https://www.walmart.com/ip/Sony-PlayStation-5-Digital-Edition/493824815'
 		},
 		{
 			brand: 'microsoft',


### PR DESCRIPTION
### Description
`ps5 console` and `ps5 digital` models both incorrectly shared the same URL in the Walmart model.

This PR corrects `ps5 digital` URL to point to the correct product page.