### PR TITLE
chore(newegg): add 3080 vision oc

### DIFF
--- a/src/store/model/newegg.ts
+++ b/src/store/model/newegg.ts
@@ -356,6 +356,16 @@ export const Newegg: Store = {
 				'https://www.newegg.com/gigabyte-geforce-rtx-3070-gv-n3070vision-oc-8gd/p/N82E16814932360'
 		},
 		{
+			brand: 'gigabyte',
+			cartUrl:
+				'https://secure.newegg.com/Shopping/AddtoCart.aspx?Submit=ADD&ItemList=N82E16814932337',
+			itemNumber: '14-932-337',
+			model: 'vision oc',
+			series: '3080',
+			url:
+				'https://www.newegg.com/gigabyte-geforce-rtx-3070-gv-n3070vision-oc-8gd/p/N82E16814932337'
+		},
+		{
 			brand: 'asus',
 			cartUrl:
 				'https://secure.newegg.com/Shopping/AddtoCart.aspx?Submit=ADD&ItemList=N82E16814126459',


### PR DESCRIPTION
### Description

Adds the Gigabyte 3080 VISION OC to Newegg's list.