### PR TITLE
feat(store): add `PlayStation` store

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ environment variables are **optional**._
 | Office Depot | `officedepot`|
 | Overclockers (UK) | `overclockers`|
 | PCComponentes (ES) | `pccomponentes`|
+| PlayStation (ES) | `playstation`|
 | PNY | `pny`|
 | Proshop (DE) | `proshop-de`|
 | Proshop (DK) | `proshop-dk`|

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ environment variables are **optional**._
 | Office Depot | `officedepot`|
 | Overclockers (UK) | `overclockers`|
 | PCComponentes (ES) | `pccomponentes`|
-| PlayStation (ES) | `playstation`|
+| PlayStation | `playstation`|
 | PNY | `pny`|
 | Proshop (DE) | `proshop-de`|
 | Proshop (DK) | `proshop-dk`|

--- a/src/store/model/index.ts
+++ b/src/store/model/index.ts
@@ -48,6 +48,7 @@ import {NvidiaApi} from './nvidia-api';
 import {OfficeDepot} from './officedepot';
 import {Overclockers} from './overclockers';
 import {PCComponentes} from './pccomponentes';
+import {PlayStation} from './playstation';
 import {Pny} from './pny';
 import {ProshopDE} from './proshop-de';
 import {ProshopDK} from './proshop-dk';
@@ -111,6 +112,7 @@ export const storeList = new Map([
 	[OfficeDepot.name, OfficeDepot],
 	[Overclockers.name, Overclockers],
 	[PCComponentes.name, PCComponentes],
+	[PlayStation.name, PlayStation],
 	[Pny.name, Pny],
 	[ProshopDE.name, ProshopDE],
 	[ProshopDK.name, ProshopDK],

--- a/src/store/model/playstation.ts
+++ b/src/store/model/playstation.ts
@@ -5,7 +5,7 @@ export const PlayStation: Store = {
 	labels: {
 		inStock: {
 			container: '.productHero-info .button-placeholder',
-			text: ['Add'],
+			text: ['Add']
 		}
 	},
 	links: [

--- a/src/store/model/playstation.ts
+++ b/src/store/model/playstation.ts
@@ -1,0 +1,46 @@
+import {Store} from './store';
+import fetch from 'node-fetch';
+
+export const PlayStation: Store = {
+	labels: {
+		inStock: {
+			container: '.productHero-info .button-placeholder',
+			text: ['Add']
+		}
+	},
+	links: [
+		{
+			brand: 'test:brand',
+			model: 'test:model',
+			series: 'test:series',
+			url: 'https://direct.playstation.com/en-us/accessories/accessory/dualsense-wireless-controller.3005715',
+            itemNumber: '3005715'
+        },
+        {
+			brand: 'sony',
+			model: 'ps5 console',
+			series: 'sonyps5c',
+			url: 'https://direct.playstation.com/en-us/consoles/console/playstation5-console.3005816',
+			itemNumber: '3005816'
+        },
+        {
+			brand: 'sony',
+			model: 'ps5 digital',
+			series: 'sonyps5de',
+            url: 'https://direct.playstation.com/en-us/consoles/console/playstation5-digital-edition-console.3005817',
+            itemNumber: '3005817'
+		}
+	],
+	name: 'playstation',
+	realTimeInventoryLookup: async (itemNumber: string) => {
+		const request_url =
+			'https://api.direct.playstation.com/commercewebservices/ps-direct-us/products/productList?fields=BASIC&productCodes=' +
+			itemNumber;
+		const response = await fetch(request_url);
+        const response_json = await response.json();
+        if (response_json.products[0].stock.stockLevelStatus !== 'outOfStock' && response_json.products[0].maxOrderQuantity >= 1) {
+            return true;
+        }
+		return false;
+	}
+};

--- a/src/store/model/playstation.ts
+++ b/src/store/model/playstation.ts
@@ -1,4 +1,4 @@
-import { Store } from './store';
+import {Store} from './store';
 import fetch from 'node-fetch';
 
 export const PlayStation: Store = {
@@ -6,7 +6,7 @@ export const PlayStation: Store = {
 		inStock: {
 			container: '.productHero-info .button-placeholder',
 			text: ['Add'],
-		},
+		}
 	},
 	links: [
 		{
@@ -15,7 +15,7 @@ export const PlayStation: Store = {
 			model: 'test:model',
 			series: 'test:series',
 			url:
-				'https://direct.playstation.com/en-us/accessories/accessory/dualsense-wireless-controller.3005715',
+				'https://direct.playstation.com/en-us/accessories/accessory/dualsense-wireless-controller.3005715'
 		},
 		{
 			brand: 'sony',
@@ -23,7 +23,7 @@ export const PlayStation: Store = {
 			model: 'ps5 console',
 			series: 'sonyps5c',
 			url:
-				'https://direct.playstation.com/en-us/consoles/console/playstation5-console.3005816',
+				'https://direct.playstation.com/en-us/consoles/console/playstation5-console.3005816'
 		},
 		{
 			brand: 'sony',
@@ -31,8 +31,8 @@ export const PlayStation: Store = {
 			model: 'ps5 digital',
 			series: 'sonyps5de',
 			url:
-				'https://direct.playstation.com/en-us/consoles/console/playstation5-digital-edition-console.3005817',
-		},
+				'https://direct.playstation.com/en-us/consoles/console/playstation5-digital-edition-console.3005817'
+		}
 	],
 	name: 'playstation',
 	realTimeInventoryLookup: async (itemNumber: string) => {
@@ -47,6 +47,7 @@ export const PlayStation: Store = {
 		) {
 			return true;
 		}
+
 		return false;
-	},
+	}
 };

--- a/src/store/model/playstation.ts
+++ b/src/store/model/playstation.ts
@@ -1,35 +1,38 @@
-import {Store} from './store';
+import { Store } from './store';
 import fetch from 'node-fetch';
 
 export const PlayStation: Store = {
 	labels: {
 		inStock: {
 			container: '.productHero-info .button-placeholder',
-			text: ['Add']
-		}
+			text: ['Add'],
+		},
 	},
 	links: [
 		{
 			brand: 'test:brand',
+			itemNumber: '3005715',
 			model: 'test:model',
 			series: 'test:series',
-			url: 'https://direct.playstation.com/en-us/accessories/accessory/dualsense-wireless-controller.3005715',
-            itemNumber: '3005715'
-        },
-        {
+			url:
+				'https://direct.playstation.com/en-us/accessories/accessory/dualsense-wireless-controller.3005715',
+		},
+		{
 			brand: 'sony',
+			itemNumber: '3005816',
 			model: 'ps5 console',
 			series: 'sonyps5c',
-			url: 'https://direct.playstation.com/en-us/consoles/console/playstation5-console.3005816',
-			itemNumber: '3005816'
-        },
-        {
+			url:
+				'https://direct.playstation.com/en-us/consoles/console/playstation5-console.3005816',
+		},
+		{
 			brand: 'sony',
+			itemNumber: '3005817',
 			model: 'ps5 digital',
 			series: 'sonyps5de',
-            url: 'https://direct.playstation.com/en-us/consoles/console/playstation5-digital-edition-console.3005817',
-            itemNumber: '3005817'
-		}
+			url:
+				'https://direct.playstation.com/en-us/consoles/console/playstation5-digital-edition-console.3005817',
+		},
 	],
 	name: 'playstation',
 	realTimeInventoryLookup: async (itemNumber: string) => {
@@ -37,10 +40,13 @@ export const PlayStation: Store = {
 			'https://api.direct.playstation.com/commercewebservices/ps-direct-us/products/productList?fields=BASIC&productCodes=' +
 			itemNumber;
 		const response = await fetch(request_url);
-        const response_json = await response.json();
-        if (response_json.products[0].stock.stockLevelStatus !== 'outOfStock' && response_json.products[0].maxOrderQuantity >= 1) {
-            return true;
-        }
+		const response_json = await response.json();
+		if (
+			response_json.products[0].stock.stockLevelStatus !== 'outOfStock' &&
+			response_json.products[0].maxOrderQuantity >= 0
+		) {
+			return true;
+		}
 		return false;
-	}
+	},
 };


### PR DESCRIPTION
### Description

- Add PlayStation store for PS5 consoles (closes #804)


I have not added support for the `outOfStock` label, due to Playstation store output both 'Add', and 'Out of Stock' where the appropriate stock label is then hidden on load. `lookupCardInStock` config is set to `requireVisible: true` for the `inStock` label but not any other label, meaning I can only implement an `inStock` label alongside using `realTimeInventoryLookup` for validation.