### PR TITLE
feat(playstation): add `outOfStock` label

### DIFF
--- a/src/store/model/playstation.ts
+++ b/src/store/model/playstation.ts
@@ -4,8 +4,12 @@ import fetch from 'node-fetch';
 export const PlayStation: Store = {
 	labels: {
 		inStock: {
-			container: '.productHero-info .button-placeholder',
+			container: '.productHero-info .add-to-cart:not(.hide)',
 			text: ['Add']
+		},
+		outOfStock: {
+			container: '.productHero-info .out-stock-wrpr:not(.hide)',
+			text: ['Out of Stock']
 		}
 	},
 	links: [


### PR DESCRIPTION
### Description

- Added outOfStock label to PlayStation store by using `:not(.hide)` class selector - closes #809

