### PR TITLE
fix(config): correcting newline split for multiple user agents

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -23,8 +23,8 @@ function envOrArray(
 	array?: string[]
 ): string[] {
 	return (environment
-		? environment.includes('\n')
-			? environment.split('\n')
+		? environment.includes('\\n')
+			? environment.split('\\n')
 			: environment.split(',')
 		: array ?? []
 	).map((s) => s.trim());


### PR DESCRIPTION
<!-- Please use Conventional Commits to label your title -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/ -->
<!-- Example: feat: allow provided config object to extend other configs  -->

### Description

When using multiple strings split by `\n` for `USER_AGENT`, user agents end up being split by `,` due to `\n` not being escaped properly.

### Testing

Given the following in `.env`:
    
    USER_AGENT=Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/86.0.4240.193 Safari/537.36 \n Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:82.0) Gecko/20100101 Firefox/82.0 \n Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.0 Safari/605.1.15

`config.userAgents` becomes:

    [
    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML',
    'like Gecko) Chrome/86.0.4240.193 Safari/537.36 \\n Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:82.0) Gecko/20100101 Firefox/82.0 \\n Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML',
    'like Gecko) Version/14.0 Safari/605.1.15'
    ]

After this proposed fix, `config.userAgents` becomes:

    [
      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/86.0.4240.193 Safari/537.36',
      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:82.0) Gecko/20100101 Firefox/82.0',
      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.0 Safari/605.1.15'
]

<!-- Please describe the tests that you ran to verify your changes. -->
<!-- Provide instructions so we can reproduce. -->
<!-- Please also list any relevant details for your test configuration -->

### New dependencies

<!-- List any dependencies that are required for this change. -->
<!-- Otherwise, delete section. -->
