### PR TITLE
fix(store): Move store check earlier to not try every store constantly

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@ import {logger} from './logger';
 import puppeteer from 'puppeteer-extra';
 import resourceBlock from 'puppeteer-extra-plugin-block-resources';
 import stealthPlugin from 'puppeteer-extra-plugin-stealth';
-import {storeList} from './store/model';
+import {storeList, getStores} from './store/model';
 import {tryLookupAndLoop} from './store';
 
 puppeteer.use(stealthPlugin());
@@ -60,6 +60,10 @@ async function main() {
 	});
 
 	for (const store of storeList.values()) {
+	  if (!getStores().has(store.name)) {
+	     logger.debug(`[${store.name}] Skipped store...`);
+	     continue;
+	  }
 		logger.debug('store links', {meta: {links: store.links}});
 		if (store.setupAction !== undefined) {
 			store.setupAction(browser);

--- a/src/store/lookup.ts
+++ b/src/store/lookup.ts
@@ -1,5 +1,5 @@
 import {Browser, Page, Response} from 'puppeteer';
-import {Link, Store, getStores} from './model';
+import {Link, Store} from './model';
 import {Print, logger} from '../logger';
 import {Selector, cardPrice, pageIncludesLabels} from './includes-labels';
 import {
@@ -30,10 +30,6 @@ const linkBuilderLastRunTimes: Record<string, number> = {};
  * @param store Vendor of graphics cards.
  */
 async function lookup(browser: Browser, store: Store) {
-	if (!getStores().has(store.name)) {
-		return;
-	}
-
 	/* eslint-disable no-await-in-loop */
 	for (const link of store.links) {
 		if (!filterStoreLink(link)) {


### PR DESCRIPTION
<!-- Please use Conventional Commits to label your title -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/ -->
<!-- Example: feat: allow provided config object to extend other configs  -->

### Description

<!-- Fixes #(issue) -->
<!-- Please also include relevant motivation and context. -->
Providing a store config does not prevent the store from being scheduled. This causes extra wake up processing and pollutes the logs when not needed. This allows for much easier debugging and seeing what stores are doing by removing logs for stores that weren't actually doing anything.

### Testing

<!-- Please describe the tests that you ran to verify your changes. -->
<!-- Provide instructions so we can reproduce. -->
<!-- Please also list any relevant details for your test configuration -->
Ran the application and verified the log message was printed only once per store and was not repeated, where as before it was repeated for every store every 10s.
