### PR TITLE
chore(amazon): add big navi links

### DIFF
--- a/src/store/model/amazon.ts
+++ b/src/store/model/amazon.ts
@@ -425,6 +425,46 @@ export const Amazon: Store = {
 			url: 'https://www.amazon.com/dp/B0815Y8J9N'
 		},
 		{
+			brand: 'gigabyte',
+			cartUrl:
+				'https://www.amazon.com/gp/aws/cart/add.html?ASIN.1=B08NS4W2ZY&Quantity.1=1',
+			model: 'amd reference',
+			series: 'rx6800xt',
+			url: 'https://www.amazon.com/dp/B08NS4W2ZY'
+		},
+		{
+			brand: 'sapphire',
+			cartUrl:
+				'https://www.amazon.com/gp/aws/cart/add.html?ASIN.1=B08MVC76SR&Quantity.1=1',
+			model: 'amd reference',
+			series: 'rx6800xt',
+			url: 'https://www.amazon.com/dp/B08MVC76SR'
+		},
+		{
+			brand: 'xfx',
+			cartUrl:
+				'https://www.amazon.com/gp/aws/cart/add.html?ASIN.1=B08N6ZLX9B&Quantity.1=1',
+			model: 'amd reference',
+			series: 'rx6800xt',
+			url: 'https://www.amazon.com/dp/B08N6ZLX9B'
+		},
+		{
+			brand: 'powercolor',
+			cartUrl:
+				'https://www.amazon.com/gp/aws/cart/add.html?ASIN.1=B08MNZM5TK&Quantity.1=1',
+			model: 'amd reference',
+			series: 'rx6800',
+			url: 'https://www.amazon.com/dp/B08MNZM5TK'
+		},
+		{
+			brand: 'sapphire',
+			cartUrl:
+				'https://www.amazon.com/gp/aws/cart/add.html?ASIN.1=B08MVCLBWK&Quantity.1=1',
+			model: 'amd reference',
+			series: 'rx6800',
+			url: 'https://www.amazon.com/dp/B08MVCLBWK'
+		},
+		{
 			brand: 'sony',
 			cartUrl:
 				'https://www.amazon.com/gp/aws/cart/add.html?ASIN.1=B08FC5L3RG&Quantity.1=1',

--- a/src/store/model/store.ts
+++ b/src/store/model/store.ts
@@ -28,6 +28,7 @@ export type Brand =
 	| 'sapphire'
 	| 'sony'
 	| 'xfx'
+	| 'powercolor'
 	| 'zotac';
 
 export type Series =


### PR DESCRIPTION
### Description

Fixes #(879)
Adds Big Navi links for Amazon (US)

### Testing

Ran with these new entries and had no issues.
