### PR TITLE
feat(store): add corsair sfx PSUs

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -316,6 +316,7 @@ const store = {
 			ryzen5800: envOrNumber(process.env.MAX_PRICE_SERIES_RYZEN5800),
 			ryzen5900: envOrNumber(process.env.MAX_PRICE_SERIES_RYZEN5900),
 			ryzen5950: envOrNumber(process.env.MAX_PRICE_SERIES_RYZEN5950),
+			sf: envOrNumber(process.env.MAX_PRICE_SERIES_CORSAIR_SF),
 			sonyps5c: -1,
 			sonyps5de: -1,
 			'test:series': -1,

--- a/src/store/model/amazon.ts
+++ b/src/store/model/amazon.ts
@@ -451,6 +451,22 @@ export const Amazon: Store = {
 			model: 'xbox series s',
 			series: 'xboxss',
 			url: 'https://www.amazon.com/dp/B08G9J44ZN'
+		},
+		{
+			brand: 'corsair',
+			cartUrl: 
+				'https://www.amazon.com/gp/aws/cart/add.html?ASIN.1=B07M63H81H&Quantity.1=1',
+			model: '750 platinum',
+			series: 'sf',
+			url: 'https://www.amazon.com/dp/B07M63H81H'
+		},
+		{
+			brand: 'corsair',
+			cartUrl:
+				'https://www.amazon.com/gp/aws/cart/add.html?ASIN.1=B07F84FJ1G&Quantity.1=1',
+			model: '600 platinum',
+			series: 'sf',
+			url: 'https://www.amazon.com/dp/B07F84FJ1G'
 		}
 	],
 	name: 'amazon'

--- a/src/store/model/amazon.ts
+++ b/src/store/model/amazon.ts
@@ -454,7 +454,7 @@ export const Amazon: Store = {
 		},
 		{
 			brand: 'corsair',
-			cartUrl: 
+			cartUrl:
 				'https://www.amazon.com/gp/aws/cart/add.html?ASIN.1=B07M63H81H&Quantity.1=1',
 			model: '750 platinum',
 			series: 'sf',

--- a/src/store/model/bandh.ts
+++ b/src/store/model/bandh.ts
@@ -199,7 +199,8 @@ export const BAndH: Store = {
 			brand: 'corsair',
 			model: '750 platinum',
 			series: 'sf',
-			url: 'https://www.bhphotovideo.com/c/product/1560680-REG/corsair_cp_9020186_na_corsair_sf750_power_supply.html'
+			url:
+				'https://www.bhphotovideo.com/c/product/1560680-REG/corsair_cp_9020186_na_corsair_sf750_power_supply.html'
 		}
 	],
 	name: 'bandh'

--- a/src/store/model/bandh.ts
+++ b/src/store/model/bandh.ts
@@ -187,6 +187,19 @@ export const BAndH: Store = {
 			series: 'ryzen5600',
 			url:
 				'https://www.bhphotovideo.com/c/product/1598377-REG/amd_100_100000065box_ryzen_5_5600x_3_7.html'
+		},
+		{
+			brand: 'amd',
+			model: '5600x',
+			series: 'ryzen5600',
+			url:
+				'https://www.bhphotovideo.com/c/product/1598377-REG/amd_100_100000065box_ryzen_5_5600x_3_7.html'
+		},
+		{
+			brand: 'corsair',
+			model: '750 platinum',
+			series: 'sf',
+			url: 'https://www.bhphotovideo.com/c/product/1560680-REG/corsair_cp_9020186_na_corsair_sf750_power_supply.html'
 		}
 	],
 	name: 'bandh'

--- a/src/store/model/bestbuy.ts
+++ b/src/store/model/bestbuy.ts
@@ -412,7 +412,7 @@ export const BestBuy: Store = {
 			model: '750 platinum',
 			series: 'sf',
 			url:
-			'https://www.bestbuy.com/site/corsair-sf-series-750w-atx12v-2-4-eps12v-2-92-sfx12v-80-plus-platinum-modular-power-supply-black/6351845.p?skuId=6351845'
+				'https://www.bestbuy.com/site/corsair-sf-series-750w-atx12v-2-4-eps12v-2-92-sfx12v-80-plus-platinum-modular-power-supply-black/6351845.p?skuId=6351845'
 		},
 		{
 			brand: 'corsair',

--- a/src/store/model/bestbuy.ts
+++ b/src/store/model/bestbuy.ts
@@ -405,6 +405,24 @@ export const BestBuy: Store = {
 			series: 'rx6800xt',
 			url:
 				'https://www.bestbuy.com/site/xfx-amd-radeon-rx-6800xt-16gb-gddr6-pci-express-4-0-gaming-graphics-card-black/6441226.p?skuId=6441226'
+		},
+		{
+			brand: 'corsair',
+			cartUrl: 
+			'https://api.bestbuy.com/click/-/6351845/cart',
+			model: '750 platinum',
+			series: 'sf',
+			url: 
+				'https://www.bestbuy.com/site/corsair-sf-series-750w-atx12v-2-4-eps12v-2-92-sfx12v-80-plus-platinum-modular-power-supply-black/6351845.p?skuId=6351845'
+		},
+		{
+			brand: 'corsair',
+			cartUrl: 
+			'https://api.bestbuy.com/click/-/6351844/cart',
+			model: '600 platinum',
+			series: 'sf',
+			url: 
+				'https://www.bestbuy.com/site/corsair-sf-series-600w-atx12v-2-4-eps12v-2-92-sfx12v-80-plus-platinum-modular-power-supply-black/6351844.p?skuId=6351844'
 		}
 	],
 	name: 'bestbuy'

--- a/src/store/model/bestbuy.ts
+++ b/src/store/model/bestbuy.ts
@@ -408,20 +408,18 @@ export const BestBuy: Store = {
 		},
 		{
 			brand: 'corsair',
-			cartUrl: 
-			'https://api.bestbuy.com/click/-/6351845/cart',
+			cartUrl: 'https://api.bestbuy.com/click/-/6351845/cart',
 			model: '750 platinum',
 			series: 'sf',
-			url: 
-				'https://www.bestbuy.com/site/corsair-sf-series-750w-atx12v-2-4-eps12v-2-92-sfx12v-80-plus-platinum-modular-power-supply-black/6351845.p?skuId=6351845'
+			url:
+			'https://www.bestbuy.com/site/corsair-sf-series-750w-atx12v-2-4-eps12v-2-92-sfx12v-80-plus-platinum-modular-power-supply-black/6351845.p?skuId=6351845'
 		},
 		{
 			brand: 'corsair',
-			cartUrl: 
-			'https://api.bestbuy.com/click/-/6351844/cart',
+			cartUrl: 'https://api.bestbuy.com/click/-/6351844/cart',
 			model: '600 platinum',
 			series: 'sf',
-			url: 
+			url:
 				'https://www.bestbuy.com/site/corsair-sf-series-600w-atx12v-2-4-eps12v-2-92-sfx12v-80-plus-platinum-modular-power-supply-black/6351844.p?skuId=6351844'
 		}
 	],

--- a/src/store/model/corsair.ts
+++ b/src/store/model/corsair.ts
@@ -1,0 +1,37 @@
+import {Store} from './store';
+
+export const Corsair: Store = {
+	labels: {
+		inStock: {
+			container: '.add_to_cart_form',
+			text: ['add to cart']
+		},
+		maxPrice: {
+			container: '.product-price',
+			euroFormat: false
+		}
+	},
+	links: [
+		{
+			brand: 'test:brand',
+			model: 'test:model',
+			series: 'test:series',
+			url: 'https://www.corsair.com/us/en/Categories/Products/Power-Supply-Units/Power-Supply-Units-Advanced/SF-Series/p/CP-9020181-NA'
+		},
+		{
+			brand: 'corsair',
+			model: '750 platinum',
+			series: 'sf',
+			url: 
+				'https://www.corsair.com/us/en/Categories/Products/Power-Supply-Units/Power-Supply-Units-Advanced/SF-Series/p/CP-9020186-NA'
+		},
+		{
+			brand: 'corsair',
+			model: '600 platinum',
+			series: 'sf',
+			url: 
+				'https://www.corsair.com/us/en/Categories/Products/Power-Supply-Units/Power-Supply-Units-Advanced/SF-Series/p/CP-9020182-NA'
+		},
+	],
+	name: 'corsair'
+};

--- a/src/store/model/corsair.ts
+++ b/src/store/model/corsair.ts
@@ -16,22 +16,23 @@ export const Corsair: Store = {
 			brand: 'test:brand',
 			model: 'test:model',
 			series: 'test:series',
-			url: 'https://www.corsair.com/us/en/Categories/Products/Power-Supply-Units/Power-Supply-Units-Advanced/SF-Series/p/CP-9020181-NA'
+			url:
+				'https://www.corsair.com/us/en/Categories/Products/Power-Supply-Units/Power-Supply-Units-Advanced/SF-Series/p/CP-9020181-NA'
 		},
 		{
 			brand: 'corsair',
 			model: '750 platinum',
 			series: 'sf',
-			url: 
+			url:
 				'https://www.corsair.com/us/en/Categories/Products/Power-Supply-Units/Power-Supply-Units-Advanced/SF-Series/p/CP-9020186-NA'
 		},
 		{
 			brand: 'corsair',
 			model: '600 platinum',
 			series: 'sf',
-			url: 
+			url:
 				'https://www.corsair.com/us/en/Categories/Products/Power-Supply-Units/Power-Supply-Units-Advanced/SF-Series/p/CP-9020182-NA'
-		},
+		}
 	],
 	name: 'corsair'
 };

--- a/src/store/model/index.ts
+++ b/src/store/model/index.ts
@@ -26,6 +26,7 @@ import {Ccl} from './ccl';
 import {Computeruniverse} from './computeruniverse';
 import {Coolblue} from './coolblue';
 import {Coolmod} from './coolmod';
+import {Corsair} from './corsair';
 import {Currys} from './currys';
 import {Cyberport} from './cyberport';
 import {Ebuyer} from './ebuyer';
@@ -91,6 +92,7 @@ export const storeList = new Map([
 	[Computeruniverse.name, Computeruniverse],
 	[Coolblue.name, Coolblue],
 	[Coolmod.name, Coolmod],
+	[Corsair.name, Corsair],
 	[Currys.name, Currys],
 	[Cyberport.name, Cyberport],
 	[Ebuyer.name, Ebuyer],

--- a/src/store/model/store.ts
+++ b/src/store/model/store.ts
@@ -15,6 +15,7 @@ export type Brand =
 	| 'amd'
 	| 'asrock'
 	| 'asus'
+	| 'corsair'
 	| 'evga'
 	| 'gainward'
 	| 'gigabyte'
@@ -44,6 +45,7 @@ export type Series =
 	| 'ryzen5950'
 	| 'sonyps5c'
 	| 'sonyps5de'
+	| 'sf'
 	| 'xboxsx'
 	| 'xboxss';
 
@@ -53,6 +55,8 @@ export type Model =
 	| '5800x'
 	| '5900x'
 	| '5950x'
+	| '600 platinum'
+	| '750 platinum'
 	| 'amd reference'
 	| 'amp extreme holo'
 	| 'amp holo'


### PR DESCRIPTION
<!-- Please use Conventional Commits to label your title -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/ -->
improvement: Allow monitoring of corsair sfx power supplies

### Description

Fixes #758 
Adds support for corsair sf series (750, 600), at Best Buy, BandH, Amazon
Adds Corsair store

### Testing

add corsair as brand in .env
add stores: amazon, bandh, bestbuy, corsair
run