### PR TITLE
fix(newegg): typo in 5800x url

### DIFF
--- a/src/store/model/newegg.ts
+++ b/src/store/model/newegg.ts
@@ -570,7 +570,7 @@ export const Newegg: Store = {
 			itemNumber: '19-113-665',
 			model: '5800x',
 			series: 'ryzen5800',
-			url: 'https://www.newegg.com/amd-ryzen-9-5900x/p/N82E16819113665'
+			url: 'https://www.newegg.com/amd-ryzen-7-5800x/p/N82E16819113665'
 		},
 		{
 			brand: 'amd',


### PR DESCRIPTION
<!-- Please use Conventional Commits to label your title -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/ -->
<!-- Example: feat: allow provided config object to extend other configs  -->

### Description

<!-- Fixes #(issue) -->
Original URL resolved properly due to Item# being correct, but my OCD noticed the URL was referencing the 5900x :)
<!-- Please also include relevant motivation and context. -->

### Testing

<!-- Please describe the tests that you ran to verify your changes. -->
<!-- Provide instructions so we can reproduce. -->
<!-- Please also list any relevant details for your test configuration -->

### New dependencies

<!-- List any dependencies that are required for this change. -->
<!-- Otherwise, delete section. -->
