### PR TITLE
feat: option for max operating duration

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ environment variables are **optional**._
 | `MAX_PRICE_SERIES_RYZEN5900` | Maximum price allowed for a match, applies AMD 5900 series cpus | Default: leave empty for no limit, otherwise enter a price (enter whole dollar amounts only, avoid use of: dollar symbols, commas, and periods.) e.g.: `1234` - CPUs above `1234` will be skipped. |
 | `MAX_PRICE_SERIES_RYZEN5950` | Maximum price allowed for a match, applies AMD 5950 series cpus | Default: leave empty for no limit, otherwise enter a price (enter whole dollar amounts only, avoid use of: dollar symbols, commas, and periods.) e.g.: `1234` - CPUs above `1234` will be skipped. |
 | `MAX_PRICE_SERIES_CORSAIR_SF` | Maximum price allowed for a match, applies to Corsair PSUs | Default: leave empty for no limit, otherwise enter a price (enter whole dollar amounts only, avoid use of: dollar symbols, commas, and periods.) e.g.: `1234` - PSUs above `1234` will be skipped. |
+| `MAX_RUNTIME` | Maximum duration the program should run for. This is useful when defining windows of operation. | Default: leave empty for no limit, otherwise enter a number in seconds e.g.: `1234`. |
 | `MICROCENTER_LOCATION` | Specific MicroCenter location(s) to search | Comma separated, e.g.: `marietta,duluth`, default: `web` |
 | `NVIDIA_ADD_TO_CART_ATTEMPTS` | The maximum number of times the `nvidia-api` add to cart feature will be attempted before failing | Default: `10` |
 | `NVIDIA_SESSION_TTL` | The time in milliseconds to keep the cart active while using `nvidia-api` | Default: `60000` |

--- a/src/config.ts
+++ b/src/config.ts
@@ -378,11 +378,11 @@ export const config = {
 	browser,
 	docker,
 	logLevel,
+	maxRunTime,
 	notifications,
 	nvidia,
 	page,
 	proxy,
-	maxRunTime,
 	store
 };
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -367,6 +367,8 @@ const store = {
 	})
 };
 
+const maxRunTime = envOrNumber(process.env.MAX_RUNTIME);
+
 export const defaultStoreData = {
 	maxPageSleep: browser.maxSleep,
 	minPageSleep: browser.minSleep
@@ -380,7 +382,8 @@ export const config = {
 	nvidia,
 	page,
 	proxy,
-	store
+	store,
+	maxRunTime
 };
 
 export function setConfig(newConfig: any) {

--- a/src/config.ts
+++ b/src/config.ts
@@ -382,8 +382,8 @@ export const config = {
 	nvidia,
 	page,
 	proxy,
-	store,
-	maxRunTime
+	maxRunTime,
+	store
 };
 
 export function setConfig(newConfig: any) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -71,9 +71,11 @@ async function main() {
 	await startAPIServer();
 
 	if (config.maxRunTime) {
-		setTimeout(() => {
-			logger.info(`We've been searching for over ${config.maxRunTime} seconds as configured by MAX_RUNTIME. Time to call it quits for now. Gracefully stopping program.`);
-			stopAndExit();
+		setTimeout(async () => {
+			logger.info(
+				`We've been searching for over ${config.maxRunTime} seconds as configured by MAX_RUNTIME. Time to call it quits for now. Gracefully stopping program.`
+			);
+			await stopAndExit();
 		}, config.maxRunTime);
 	}
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -69,6 +69,13 @@ async function main() {
 	}
 
 	await startAPIServer();
+
+	if (config.maxRunTime) {
+		setTimeout(() => {
+			logger.info(`We've been searching for over ${config.maxRunTime} seconds as configured by MAX_RUNTIME. Time to call it quits for now. Gracefully stopping program.`);
+			stopAndExit();
+		}, config.maxRunTime);
+	}
 }
 
 async function stop() {

--- a/src/store/lookup.ts
+++ b/src/store/lookup.ts
@@ -218,7 +218,7 @@ async function lookupCardInStock(store: Store, page: Page, link: Link) {
 }
 
 export async function tryLookupAndLoop(browser: Browser, store: Store) {
-	if (!browser.isConnected()) {
+	if (!browser || !browser.isConnected()) {
 		logger.debug(`[${store.name}] Ending this loop as browser is disposed...`);
 		return;
 	}


### PR DESCRIPTION
<!-- Please use Conventional Commits to label your title -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/ -->
<!-- Example: feat: allow provided config object to extend other configs  -->

### Description
Enables the ability to run this program for a specified period of time. This is especially useful when defining windows of operation.
For example, I want this program to only search for cards during the hours of 9AM -> 11PM as I don't want to be woken up in the middle of the night for card alerts. Setting a cron schedule to run daily at 9AM and a `MAX_RUNTIME` env var of `14400` achieves this. 
If I won't be actionable on the alerts this program sends out, why have it running. 
This is also useful for anybody looking to run this in a containerized environment in the cloud, and don't want to incur extra server costs during scheduled downtimes 

<!-- Fixes #(issue) -->
<!-- Please also include relevant motivation and context. -->

### Testing

<!-- Please describe the tests that you ran to verify your changes. -->
<!-- Provide instructions so we can reproduce. -->
<!-- Please also list any relevant details for your test configuration -->
Tested locally. Don't see any unit tests in this project, but happy to add some if needed!

### New dependencies

<!-- List any dependencies that are required for this change. -->
<!-- Otherwise, delete section. -->
