### PR TITLE
chore(amd): add rx6800

### DIFF
--- a/src/store/model/amd.ts
+++ b/src/store/model/amd.ts
@@ -57,6 +57,14 @@ export const Amd: Store = {
 			model: 'amd reference',
 			series: 'rx6800xt',
 			url: 'https://www.amd.com/en/direct-buy/5458372800/us'
+		},
+		{
+			brand: 'amd',
+			cartUrl:
+				'https://www.amd.com/en/direct-buy/5458373400/us?add-to-cart=true',
+			model: 'amd reference',
+			series: 'rx6800',
+			url: 'https://www.amd.com/en/direct-buy/5458373400/us'
 		}
 	],
 	name: 'amd'


### PR DESCRIPTION
### Description

Adds the RX 6800 (non-XT) card from the AMD Direct store; only the 6800XT is available currently.

### Testing

1. Ran tracking with `STORES=amd` and `SHOW_ONLY_SERIES=rx6800`.
2. Verified `OUT OF STOCK` response. 
