### PR TITLE
fix: related products being picked up on scan

### DIFF
--- a/src/store/model/scan.ts
+++ b/src/store/model/scan.ts
@@ -74,7 +74,7 @@ export const Scan: Store = {
 	],
 	linksBuilder: {
 		builder: getProductLinksBuilder({
-			productsSelector: 'ul.productColumns li.product',
+			productsSelector: 'ul.productColumns:not(.related) li.product',
 			sitePrefix: 'https://www.scan.co.uk',
 			titleSelector: '.details .description',
 			urlSelector: 'a[href]'


### PR DESCRIPTION
### Description
There isn't an issue for this as its so small but related products were being picked up on scan. I've just changed the css selector to filter out these.

Just changed `ul.productColumns` to `ul.productColumns:not(.related)`.

### Testing

Tests weren't really necessary for this, related products were no longer picked up by the scraper. I'm not super confident in writing them but I can give it a try if its that necessary.