### PR TITLE
improvement(store): add ps5 accessories to most US retailers

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,9 @@ environment variables are **optional**._
 | `Sony PS5` | `sonyps5c` |
 | `Sony PS5 Digital Edition` | `sonyps5de` |
 | `Sony PS5 Dualsense` | `sonyps5ds` |
+| `Sony PS5 Dualsense Charger` | `sonyps5dsc` |
+| `Sony PS5 Media Remote` | `sonyps5mr` |
+| `Sony PS5 Pulse3D` | `sonyps5p3d` |
 | `Xbox Series S` | `xboxss` |
 | `Xbox Series X` | `xboxsx` |
 

--- a/README.md
+++ b/README.md
@@ -282,6 +282,7 @@ environment variables are **optional**._
 | `Corsair SFX PSU` | `sf` |
 | `Sony PS5` | `sonyps5c` |
 | `Sony PS5 Digital Edition` | `sonyps5de` |
+| `Sony PS5 Dualsense` | `sonyps5ds` |
 | `Xbox Series S` | `xboxss` |
 | `Xbox Series X` | `xboxsx` |
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -319,6 +319,7 @@ const store = {
 			sf: envOrNumber(process.env.MAX_PRICE_SERIES_CORSAIR_SF),
 			sonyps5c: -1,
 			sonyps5de: -1,
+			sonyps5ds: -1,
 			'test:series': -1,
 			xboxss: -1,
 			xboxsx: -1

--- a/src/config.ts
+++ b/src/config.ts
@@ -319,7 +319,10 @@ const store = {
 			sf: envOrNumber(process.env.MAX_PRICE_SERIES_CORSAIR_SF),
 			sonyps5c: -1,
 			sonyps5de: -1,
+			sonyps5p3d: -1,
 			sonyps5ds: -1,
+			sonyps5dsc: -1,
+			sonyps5mr: -1,
 			'test:series': -1,
 			xboxss: -1,
 			xboxsx: -1
@@ -347,6 +350,10 @@ const store = {
 		'ryzen5950',
 		'sonyps5c',
 		'sonyps5de',
+		'sonyps5ds',
+		'sonyps5dsc',
+		'sonyps5mr',
+		'sonyps5p3d',
 		'xboxss',
 		'xboxsx'
 	]),

--- a/src/store/model/amazon.ts
+++ b/src/store/model/amazon.ts
@@ -481,6 +481,38 @@ export const Amazon: Store = {
 			url: 'https://www.amazon.com/dp/B08FC6MR62'
 		},
 		{
+			brand: 'sony',
+			cartUrl:
+				'https://www.amazon.com/gp/aws/cart/add.html?ASIN.1=B08FC6C75Y&Quantity.1=1',
+			model: 'ps5 dualsense',
+			series: 'sonyps5ds',
+			url: 'https://www.amazon.com/dp/B08FC6C75Y'
+		},
+		{
+			brand: 'sony',
+			cartUrl:
+				'https://www.amazon.com/gp/aws/cart/add.html?ASIN.1=B08FC6Y4VG&Quantity.1=1',
+			model: 'ps5 dualsense charger',
+			series: 'sonyps5dsc',
+			url: 'https://www.amazon.com/dp/B08FC6Y4VG'
+		},
+		{
+			brand: 'sony',
+			cartUrl:
+				'https://www.amazon.com/gp/aws/cart/add.html?ASIN.1=B08FC6QLKN&Quantity.1=1',
+			model: 'ps5 Pulse3D',
+			series: 'sonyps5p3d',
+			url: 'https://www.amazon.com/dp/B08FC6QLKN'
+		},
+		{
+			brand: 'sony',
+			cartUrl:
+				'https://www.amazon.com/gp/aws/cart/add.html?ASIN.1=B08FC5R4KV&Quantity.1=1',
+			model: 'ps5 media remote',
+			series: 'sonyps5mr',
+			url: 'https://www.amazon.com/dp/B08FC5R4KV'
+		},
+		{
 			brand: 'microsoft',
 			model: 'xbox series x',
 			series: 'xboxsx',

--- a/src/store/model/bestbuy.ts
+++ b/src/store/model/bestbuy.ts
@@ -365,6 +365,38 @@ export const BestBuy: Store = {
 				'https://www.bestbuy.com/site/sony-playstation-5-digital-edition-console/6430161.p?skuId=6430161&intl=nosplash'
 		},
 		{
+			brand: 'sony',
+			cartUrl: 'https://api.bestbuy.com/click/-/6430163/cart',
+			model: 'ps5 dualsense',
+			series: 'sonyps5ds',
+			url:
+				'https://www.bestbuy.com/site/sony-playstation-5-dualsense-wireless-controller/6430163.p?skuId=6430163&intl=nosplash'
+		},
+		{
+			brand: 'sony',
+			cartUrl: 'https://api.bestbuy.com/click/-/6430165/cart',
+			model: 'ps5 dualsense charger',
+			series: 'sonyps5dsc',
+			url:
+				'https://www.bestbuy.com/site/sony-playstation-5-dualsense-charging-station-white/6430165.p?skuId=6430165&intl=nosplash'
+		},
+		{
+			brand: 'sony',
+			cartUrl: 'https://api.bestbuy.com/click/-/6430164/cart',
+			model: 'ps5 Pulse3D',
+			series: 'sonyps5p3d',
+			url:
+				'https://www.bestbuy.com/site/sony-playstation-pulse-3d-wireless-headset-compatible-for-both-playstation-4-playstation-5-white/6430164.p?skuId=6430164&intl=nosplash'
+		},
+		{
+			brand: 'sony',
+			cartUrl: 'https://api.bestbuy.com/click/-/6430167/cart',
+			model: 'ps5 media remote',
+			series: 'sonyps5mr',
+			url:
+				'https://www.bestbuy.com/site/sony-playstation-5-media-remote/6430167.p?skuId=6430167&intl=nosplash'
+		},
+		{
 			brand: 'microsoft',
 			model: 'xbox series x',
 			series: 'xboxsx',

--- a/src/store/model/gamestop.ts
+++ b/src/store/model/gamestop.ts
@@ -51,6 +51,13 @@ export const Gamestop: Store = {
 				'https://www.gamestop.com/video-games/playstation-5/consoles/products/playstation-5-digital-edition/11108141'
 		},
 		{
+			brand: 'sony',
+			model: 'ps5 dualsense',
+			series: 'sonyps5ds',
+			url:
+				'https://www.gamestop.com/video-games/playstation-5/accessories/products/sony-dualsense-wireless-controller/11106262.html'
+		},
+		{
 			brand: 'microsoft',
 			model: 'xbox series x',
 			series: 'xboxsx',

--- a/src/store/model/gamestop.ts
+++ b/src/store/model/gamestop.ts
@@ -58,6 +58,27 @@ export const Gamestop: Store = {
 				'https://www.gamestop.com/video-games/playstation-5/accessories/products/sony-dualsense-wireless-controller/11106262.html'
 		},
 		{
+			brand: 'sony',
+			model: 'ps5 dualsense charger',
+			series: 'sonyps5dsc',
+			url:
+				'https://www.gamestop.com/video-games/playstation-5/accessories/products/playstation-5-dualsense-charging-station/11106283.html'
+		},
+		{
+			brand: 'sony',
+			model: 'ps5 Pulse3D',
+			series: 'sonyps5p3d',
+			url:
+				'https://www.gamestop.com/video-games/playstation-5/accessories/products/playstation-5-pulse-3d-wireless-gaming-headset/11106278.html'
+		},
+		{
+			brand: 'sony',
+			model: 'ps5 media remote',
+			series: 'sonyps5mr',
+			url:
+				'https://www.gamestop.com/video-games/playstation-5/accessories/products/playstation-5-media-remote/11106279.html'
+		},
+		{
 			brand: 'microsoft',
 			model: 'xbox series x',
 			series: 'xboxsx',

--- a/src/store/model/playstation.ts
+++ b/src/store/model/playstation.ts
@@ -23,6 +23,30 @@ export const PlayStation: Store = {
 		},
 		{
 			brand: 'sony',
+			itemNumber: '3005715',
+			model: 'ps5 dualsense charger',
+			series: 'sonyps5dsc',
+			url:
+				'https://direct.playstation.com/en-us/accessories/accessory/dualsense-charging-station.3005837'
+		},
+		{
+			brand: 'sony',
+			itemNumber: '3005715',
+			model: 'ps5 Pulse3D',
+			series: 'sonyps5p3d',
+			url:
+				'https://direct.playstation.com/en-us/accessories/accessory/pulse-3d-wireless-headset.3005688'
+		},
+		{
+			brand: 'sony',
+			itemNumber: '3005715',
+			model: 'ps5 media remote',
+			series: 'sonyps5mr',
+			url:
+				'https://direct.playstation.com/en-us/accessories/accessory/media-remote.3005727'
+		},
+		{
+			brand: 'sony',
 			itemNumber: '3005816',
 			model: 'ps5 console',
 			series: 'sonyps5c',

--- a/src/store/model/playstation.ts
+++ b/src/store/model/playstation.ts
@@ -14,10 +14,10 @@ export const PlayStation: Store = {
 	},
 	links: [
 		{
-			brand: 'test:brand',
+			brand: 'sony',
 			itemNumber: '3005715',
-			model: 'test:model',
-			series: 'test:series',
+			model: 'ps5 dualsense',
+			series: 'sonyps5ds',
 			url:
 				'https://direct.playstation.com/en-us/accessories/accessory/dualsense-wireless-controller.3005715'
 		},

--- a/src/store/model/store.ts
+++ b/src/store/model/store.ts
@@ -46,6 +46,7 @@ export type Series =
 	| 'ryzen5950'
 	| 'sonyps5c'
 	| 'sonyps5de'
+	| 'sonyps5ds'
 	| 'sf'
 	| 'xboxsx'
 	| 'xboxss';
@@ -90,6 +91,7 @@ export type Model =
 	| 'phoenix'
 	| 'ps5 console'
 	| 'ps5 digital'
+	| 'ps5 dualsense'
 	| 'sg oc'
 	| 'sg'
 	| 'strix lc'

--- a/src/store/model/target.ts
+++ b/src/store/model/target.ts
@@ -31,6 +31,34 @@ export const Target: Store = {
 				'https://www.target.com/p/playstation-5-digital-edition-console/-/A-81114596'
 		},
 		{
+			brand: 'sony',
+			model: 'ps5 dualsense',
+			series: 'sonyps5ds',
+			url:
+				'https://www.target.com/p/dualsense-wireless-controller-for-playstation-5/-/A-81114477'
+		},
+		{
+			brand: 'sony',
+			model: 'ps5 dualsense charger',
+			series: 'sonyps5dsc',
+			url:
+				'https://www.target.com/p/dualsense-charging-station-for-playstation-5/-/A-81114475'
+		},
+		{
+			brand: 'sony',
+			model: 'ps5 Pulse3D',
+			series: 'sonyps5p3d',
+			url:
+				'https://www.target.com/p/sony-pulse-3d-wireless-gaming-headset-for-playstation-5/-/A-81114474'
+		},
+		{
+			brand: 'sony',
+			model: 'ps5 media remote',
+			series: 'sonyps5mr',
+			url:
+				'https://www.target.com/p/playstation-5-media-remote/-/A-81114476'
+		},
+		{
 			brand: 'microsoft',
 			model: 'xbox series x',
 			series: 'xboxsx',

--- a/src/store/model/walmart.ts
+++ b/src/store/model/walmart.ts
@@ -25,6 +25,34 @@ export const Walmart: Store = {
 				'https://www.walmart.com/ip/Sony-PlayStation-5-Digital-Edition/493824815'
 		},
 		{
+			brand: 'sony',
+			model: 'ps5 dualsense',
+			series: 'sonyps5ds',
+			url:
+				'https://www.walmart.com/ip/Sony-PlayStation-5-DualSense-Wireless-Controller/615549727'
+		},
+		{
+			brand: 'sony',
+			model: 'ps5 dualsense charger',
+			series: 'sonyps5dsc',
+			url:
+				'https://www.walmart.com/ip/seort/360463987'
+		},
+		{
+			brand: 'sony',
+			model: 'ps5 Pulse3D',
+			series: 'sonyps5p3d',
+			url:
+				'https://www.walmart.com/ip/seort/667802535'
+		},
+		{
+			brand: 'sony',
+			model: 'ps5 media remote',
+			series: 'sonyps5mr',
+			url:
+				'https://www.walmart.com/ip/seort/381848762'
+		},
+		{
 			brand: 'microsoft',
 			model: 'xbox series x',
 			series: 'xboxsx',


### PR DESCRIPTION
### Description

Updated the existing sony store dualsense stock alert to follow common item patterns adapted to the dualsense controller. Added GameStop stock alert for the same device following the same pattern.

### Testing

Minor change tested with latest release on local instance of streetmerchant
