### PR TITLE
feat(store): add some italian stores with ps5 links

### DIFF
--- a/src/store/model/amazon-it.ts
+++ b/src/store/model/amazon-it.ts
@@ -1,0 +1,37 @@
+import {Store} from './store';
+
+export const AmazonIt: Store = {
+	backoffStatusCodes: [403, 429, 503],
+	labels: {
+		captcha: {
+			container: 'body',
+			text: ['enter the characters you see below']
+		},
+		inStock: {
+			container: '#desktop_buybox',
+			text: ['Aggiungi al carrello']
+		},
+		maxPrice: {
+			container: 'span[class*="PriceString"]'
+		}
+	},
+	links: [
+		{
+			brand: 'sony',
+			cartUrl:
+				'https://www.amazon.com/gp/aws/cart/add.html?ASIN.1=B08KKJ37F7&Quantity.1=1',
+			model: 'ps5 console',
+			series: 'sonyps5c',
+			url: 'https://www.amazon.it/dp/B08KKJ37F7'
+		},
+		{
+			brand: 'sony',
+			cartUrl:
+				'https://www.amazon.it/gp/aws/cart/add.html?ASIN.1=B08KJF2D25&Quantity.1=1',
+			model: 'ps5 digital',
+			series: 'sonyps5de',
+			url: 'https://www.amazon.it/dp/B08KJF2D25'
+		}
+	],
+	name: 'amazon-it'
+};

--- a/src/store/model/comet.ts
+++ b/src/store/model/comet.ts
@@ -1,0 +1,20 @@
+import {Store} from './store';
+
+export const Comet: Store = {
+	labels: {
+		inStock: {
+			container: '.caption',
+			text: ['Aggiungi al carrello']
+		}
+	},
+	links: [
+		{
+			brand: 'sony',
+			cartUrl: 'https://www.comet.it/cart/insert/PSX01802A/online',
+			model: 'ps5 console',
+			series: 'sonyps5c',
+			url: 'https://www.comet.it/ps5/sony-playstation-5'
+		}
+	],
+	name: 'comet'
+};

--- a/src/store/model/euronics.ts
+++ b/src/store/model/euronics.ts
@@ -1,0 +1,27 @@
+import {Store} from './store';
+
+export const Euronics: Store = {
+	labels: {
+		inStock: {
+			container: '.purchaseButtonsWidth',
+			text: ['Aggiungi al carrello', 'prenota e ritira']
+		}
+	},
+	links: [
+		{
+			brand: 'sony',
+			model: 'ps5 console',
+			series: 'sonyps5c',
+			url:
+				'https://www.euronics.it/console/sony-computer/playstation-5/eProd202008906/'
+		},
+		{
+			brand: 'sony',
+			model: 'ps5 digital',
+			series: 'sonyps5de',
+			url:
+				'https://www.euronics.it/console/sony-computer/playstation-5-digital-edition/eProd202008907/'
+		}
+	],
+	name: 'euronics'
+};

--- a/src/store/model/index.ts
+++ b/src/store/model/index.ts
@@ -7,6 +7,7 @@ import {AmazonCa} from './amazon-ca';
 import {AmazonDe} from './amazon-de';
 import {AmazonEs} from './amazon-es';
 import {AmazonFr} from './amazon-fr';
+import {AmazonIt} from './amazon-it';
 import {AmazonNl} from './amazon-nl';
 import {AmazonUk} from './amazon-uk';
 import {Amd} from './amd';
@@ -23,6 +24,7 @@ import {Box} from './box';
 import {CanadaComputers} from './canadacomputers';
 import {Caseking} from './caseking';
 import {Ccl} from './ccl';
+import {Comet} from './comet';
 import {Computeruniverse} from './computeruniverse';
 import {Coolblue} from './coolblue';
 import {Coolmod} from './coolmod';
@@ -30,6 +32,7 @@ import {Corsair} from './corsair';
 import {Currys} from './currys';
 import {Cyberport} from './cyberport';
 import {Ebuyer} from './ebuyer';
+import {Euronics} from './euronics';
 import {Evga} from './evga';
 import {EvgaEu} from './evga-eu';
 import {Galaxus} from './galaxus';
@@ -58,6 +61,7 @@ import {Scan} from './scan';
 import {Store} from './store';
 import {Target} from './target';
 import {TopAchat} from './topachat';
+import {Unieuro} from './unieuro';
 import {Very} from './very';
 import {VsGamers} from './vsgamers';
 import {Walmart} from './walmart';
@@ -76,6 +80,7 @@ export const storeList = new Map([
 	[AmazonFr.name, AmazonFr],
 	[AmazonNl.name, AmazonNl],
 	[AmazonUk.name, AmazonUk],
+	[AmazonIt.name, AmazonIt],
 	[Amd.name, Amd],
 	[AmdDe.name, AmdDe],
 	[Aria.name, Aria],
@@ -90,6 +95,7 @@ export const storeList = new Map([
 	[Caseking.name, Caseking],
 	[CanadaComputers.name, CanadaComputers],
 	[Ccl.name, Ccl],
+	[Comet.name, Comet],
 	[Computeruniverse.name, Computeruniverse],
 	[Coolblue.name, Coolblue],
 	[Coolmod.name, Coolmod],
@@ -97,6 +103,7 @@ export const storeList = new Map([
 	[Currys.name, Currys],
 	[Cyberport.name, Cyberport],
 	[Ebuyer.name, Ebuyer],
+	[Euronics.name, Euronics],
 	[Evga.name, Evga],
 	[EvgaEu.name, EvgaEu],
 	[Galaxus.name, Galaxus],
@@ -124,6 +131,7 @@ export const storeList = new Map([
 	[Scan.name, Scan],
 	[Target.name, Target],
 	[TopAchat.name, TopAchat],
+	[Unieuro.name, Unieuro],
 	[Very.name, Very],
 	[VsGamers.name, VsGamers],
 	[Walmart.name, Walmart],

--- a/src/store/model/unieuro.ts
+++ b/src/store/model/unieuro.ts
@@ -1,0 +1,27 @@
+import {Store} from './store';
+
+export const Unieuro: Store = {
+	labels: {
+		inStock: {
+			container: '.price-container',
+			text: ['Aggiungi al carrello']
+		}
+	},
+	links: [
+		{
+			brand: 'sony',
+			model: 'ps5 console',
+			series: 'sonyps5c',
+			url:
+				'https://www.unieuro.it/online/Playstation-5/PlayStation-5-pidSONPS5DISC'
+		},
+		{
+			brand: 'sony',
+			model: 'ps5 digital',
+			series: 'sonyps5de',
+			url:
+				'https://www.unieuro.it/online/Playstation-5/PlayStation-5-Digital-Edition-pidSONPS5DIGITAL'
+		}
+	],
+	name: 'unieuro'
+};


### PR DESCRIPTION
<!-- Please use Conventional Commits to label your title -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/ -->
<!-- Example: feat: allow provided config object to extend other configs  -->

### Description
<!-- Fixes #(issue) -->
<!-- Please also include relevant motivation and context. -->
This PR add 4 Italian stores, namely [Uniero](https://www.unieuro.it), [Euronics](https://www.euronics.it), [Amazon-it](https://www.amazon.it), [Comet](https://www.comet.it). I only add, for now, the PlayStation 5 links for both versions. I do not check each one of the streetmerchant supported items, but I suspect that most of them do not even have a page in those stores. However, if you are interested in it, I can try to complete the store files as much as possible. 

Close #972
Close #956

### Testing
<!-- Please describe the tests that you ran to verify your changes. -->
<!-- Provide instructions so we can reproduce. -->
<!-- Please also list any relevant details for your test configuration -->
I test the in-stock check by using some other available products for each store. 



