### PR TITLE
docs: updated README.md for .env and docker issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,9 @@ filesystem changes are detected in the `src/` folder or `.env` file.
 
 To customize `streetmerchant`, make a copy of `.env-example` as `.env` and make any changes to your liking. _All
 environment variables are **optional**._
+> :page_facing_up: Don't copy empty or otherwise unused options to your `.env` as it can cause issues when running in Docker and passing in the `.env` file with the `--env-file` option.
+
+> :page_facing_up: Also don't wrap your settings values in double quotes (`"`) in the `.env` file when using Docker, as this can also cause issues.
 
 <details>
 <summary>Expand to see all available options</summary>


### PR DESCRIPTION
<!-- Please use Conventional Commits to label your title -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/ -->
<!-- Example: feat: allow provided config object to extend other configs  -->

### Description
Addresses issues when getting streetmerchant running in Docker encountered by myself and others when using the `--env-file` option with `docker run`.

Relates to #882 and #807 
<!-- Fixes #(issue) -->
<!-- Please also include relevant motivation and context. -->

### Testing
I ran a few docker run commands illustrating the types of errors seen when you either leave blank options unset in the `.env` file or wrapped certain setting values in double quotes (`"`).

**E.g.**

* Wrapping the `STORES` setting value in double quotes like `STORES="adorama,amazon,amd,asus,bandh,bestbuy,gamestop,microcenter,newegg,officedepot,target,walmart,zotac"` results in the following `warn` on startup stating `No store named zotac", skipping.` with the command `docker run --cap-add=SYS_ADMIN --name=streetmerchant -it --rm --env-file ./.env ghcr.io/jef/streetmerchant:latest`:
![image](https://user-images.githubusercontent.com/58000963/100528931-7193ba00-319f-11eb-8eb5-8ec6943a372a.png)

* Also wrapping the `MICROCENTER_LOCATION` setting value in double quotes, like `MICROCENTER_LOCATION="denver"` results in the following error when starting with `docker run --cap-add=SYS_ADMIN --name=streetmerchant -it --rm --env-file ./.env ghcr.io/jef/streetmerchant:latest`:
![image](https://user-images.githubusercontent.com/58000963/100529002-10b8b180-31a0-11eb-8091-93217a537421.png)

* Lastly there's odd startup errors regarding certain notification components (like Twilio) when the optional settings are left blank in the `.env` file, as copied from the `.env-example` file like so:
```
TWILIO_ACCOUNT_SID=""
TWILIO_AUTH_TOKEN=""
TWILIO_FROM_NUMBER=""
TWILIO_TO_NUMBER=""
```
Which results in the following error on startup when using Docker with `docker run --cap-add=SYS_ADMIN --name=streetmerchant -it --rm --env-file ./.env ghcr.io/jef/streetmerchant:latest`:
![image](https://user-images.githubusercontent.com/58000963/100529044-6725f000-31a0-11eb-8d0a-45e8b1a200ac.png)

The solution for me was to remove all wrapping double quotes from any setting values used in the `.env` file as well as removing any settings that I was not intending to use from the `.env` file. So I feel like some clarifications in the README.md are warranted to help avoid confusion for newcomers.
<!-- Please describe the tests that you ran to verify your changes. -->
<!-- Provide instructions so we can reproduce. -->
<!-- Please also list any relevant details for your test configuration -->

