### PR TITLE
chore(store): add xbox/ps5 to eu stores

### DIFF
--- a/src/store/model/alternate.ts
+++ b/src/store/model/alternate.ts
@@ -17,7 +17,10 @@ export const Alternate: Store = {
 		},
 		outOfStock: {
 			container: '.stockStatus',
-			text: ['liefertermin unbekannt']
+			text: [
+				'liefertermin unbekannt',
+				'Artikel kann nicht gekauft werden'
+			]
 		}
 	},
 	links: [
@@ -386,6 +389,18 @@ export const Alternate: Store = {
 			model: 'gaming oc',
 			series: 'rx6800xt',
 			url: 'https://www.alternate.de/product/1697044'
+		},
+		{
+			brand: 'microsoft',
+			model: 'xbox series x',
+			series: 'xboxsx',
+			url: 'https://www.alternate.de/product/1675115'
+		},
+		{
+			brand: 'microsoft',
+			model: 'xbox series s',
+			series: 'xboxss',
+			url: 'https://www.alternate.de/product/1675117'
 		}
 	],
 	name: 'alternate'

--- a/src/store/model/alternate.ts
+++ b/src/store/model/alternate.ts
@@ -15,13 +15,16 @@ export const Alternate: Store = {
 			container: 'div.price > span',
 			euroFormat: true
 		},
-		outOfStock: {
-			container: '.stockStatus',
-			text: [
-				'liefertermin unbekannt',
-				'Artikel kann nicht gekauft werden'
-			]
-		}
+		outOfStock: [
+			{
+				container: '.stockStatus',
+				text: ['liefertermin unbekannt']
+			},
+			{
+				container: '.stockStatus',
+				text: ['Artikel kann nicht gekauft werden']
+			}
+		]
 	},
 	links: [
 		{

--- a/src/store/model/amazon-de.ts
+++ b/src/store/model/amazon-de.ts
@@ -17,7 +17,13 @@ export const AmazonDe: Store = {
 		maxPrice: {
 			container: 'span[class*="PriceString"]',
 			euroFormat: true
-		}
+		},
+		outOfStock: [
+			{
+				container: '#availability',
+				text: ['Derzeit nicht verfügbar']
+			}
+		]
 	},
 	links: [
 		{
@@ -515,6 +521,22 @@ export const AmazonDe: Store = {
 			model: 'ps5 digital',
 			series: 'sonyps5de',
 			url: 'https://www.amazon.de/dp/B08H98GVK8'
+		},
+		{
+			brand: 'microsoft',
+			cartUrl:
+				'https://www.amazon.de/gp/aws/cart/add.html?ASIN.1=B08H93ZRLL&Quantity.1=1',
+			model: 'xbox series x',
+			series: 'xboxsx',
+			url: 'https://www.amazon.de/dp/B08H93ZRLL'
+		},
+		{
+			brand: 'microsoft',
+			cartUrl:
+				'https://www.amazon.de/gp/aws/cart/add.html?ASIN.1=B087VM5XC6&Quantity.1=1',
+			model: 'xbox series s',
+			series: 'xboxss',
+			url: 'https://www.amazon.de/dp/B087VM5XC6'
 		}
 	],
 	name: 'amazon-de'

--- a/src/store/model/amazon-es.ts
+++ b/src/store/model/amazon-es.ts
@@ -1,6 +1,7 @@
 import {Store} from './store';
 
 export const AmazonEs: Store = {
+	backoffStatusCodes: [403, 429, 503],
 	labels: {
 		captcha: {
 			container: 'body',
@@ -13,7 +14,13 @@ export const AmazonEs: Store = {
 		maxPrice: {
 			container: 'span[class*="PriceString"]',
 			euroFormat: true
-		}
+		},
+		outOfStock: [
+			{
+				container: '#availability',
+				text: ['No disponible']
+			}
+		]
 	},
 	links: [
 		{
@@ -159,6 +166,38 @@ export const AmazonEs: Store = {
 			model: '5950x',
 			series: 'ryzen5950',
 			url: 'https://www.amazon.es/dp/B0815Y8J9N'
+		},
+		{
+			brand: 'sony',
+			cartUrl:
+				'https://www.amazon.es/gp/aws/cart/add.html?ASIN.1=B08KKJ37F7&Quantity.1=1',
+			model: 'ps5 console',
+			series: 'sonyps5c',
+			url: 'https://www.amazon.es/dp/B08KKJ37F7'
+		},
+		{
+			brand: 'sony',
+			cartUrl:
+				'https://www.amazon.es/gp/aws/cart/add.html?ASIN.1=B08KJF2D25&Quantity.1=1',
+			model: 'ps5 digital',
+			series: 'sonyps5de',
+			url: 'https://www.amazon.es/dp/B08KJF2D25'
+		},
+		{
+			brand: 'microsoft',
+			cartUrl:
+				'https://www.amazon.es/gp/aws/cart/add.html?ASIN.1=B08H93ZRLL&Quantity.1=1',
+			model: 'xbox series x',
+			series: 'xboxsx',
+			url: 'https://www.amazon.es/dp/B08H93ZRLL'
+		},
+		{
+			brand: 'microsoft',
+			cartUrl:
+				'https://www.amazon.es/gp/aws/cart/add.html?ASIN.1=B087VM5XC6&Quantity.1=1',
+			model: 'xbox series s',
+			series: 'xboxss',
+			url: 'https://www.amazon.es/dp/B087VM5XC6'
 		}
 	],
 	name: 'amazon-es'

--- a/src/store/model/amazon-fr.ts
+++ b/src/store/model/amazon-fr.ts
@@ -1,6 +1,7 @@
 import {Store} from './store';
 
 export const AmazonFr: Store = {
+	backoffStatusCodes: [403, 429, 503],
 	labels: {
 		captcha: {
 			container: 'body',
@@ -13,7 +14,13 @@ export const AmazonFr: Store = {
 		maxPrice: {
 			container: 'span[class*="PriceString"]',
 			euroFormat: false
-		}
+		},
+		outOfStock: [
+			{
+				container: '#availability',
+				text: ['Actuellement indisponible']
+			}
+		]
 	},
 	links: [
 		{
@@ -158,13 +165,25 @@ export const AmazonFr: Store = {
 			brand: 'sony',
 			model: 'ps5 console',
 			series: 'sonyps5c',
-			url: 'https://www.amazon.fr/dp/B08GSC5D9G'
+			url: 'https://www.amazon.fr/dp/B08H93ZRK9'
 		},
 		{
 			brand: 'sony',
 			model: 'ps5 digital',
 			series: 'sonyps5de',
-			url: 'https://www.amazon.fr/dp/B08GS1N24H'
+			url: 'https://www.amazon.fr/dp/B08H98GVK8'
+		},
+		{
+			brand: 'microsoft',
+			model: 'xbox series x',
+			series: 'xboxsx',
+			url: 'https://www.amazon.fr/dp/B08H93ZRLL'
+		},
+		{
+			brand: 'microsoft',
+			model: 'xbox series s',
+			series: 'xboxss',
+			url: 'https://www.amazon.fr/dp/B087VM5XC6'
 		}
 	],
 	name: 'amazon-fr'

--- a/src/store/model/amazon-uk.ts
+++ b/src/store/model/amazon-uk.ts
@@ -39,18 +39,34 @@ export const AmazonUk: Store = {
 		{
 			brand: 'sony',
 			cartUrl:
-				'https://www.amazon.com/gp/aws/cart/add.html?ASIN.1=B08FC5L3RG&Quantity.1=1',
+				'https://www.amazon.co.uk/gp/aws/cart/add.html?ASIN.1=B08H95Y452&Quantity.1=1',
 			model: 'ps5 console',
 			series: 'sonyps5c',
-			url: 'https://www.amazon.com/dp/B08FC5L3RG'
+			url: 'https://www.amazon.co.uk/dp/B08H95Y452'
 		},
 		{
 			brand: 'sony',
 			cartUrl:
-				'https://www.amazon.com/gp/aws/cart/add.html?ASIN.1=B08H97NYGP&Quantity.1=1',
+				'https://www.amazon.co.uk/gp/aws/cart/add.html?ASIN.1=B08H97NYGP&Quantity.1=1',
 			model: 'ps5 digital',
 			series: 'sonyps5de',
-			url: 'https://www.amazon.co.uk/dp/B08H97NYGP/'
+			url: 'https://www.amazon.co.uk/dp/B08H97NYGP'
+		},
+		{
+			brand: 'microsoft',
+			cartUrl:
+				'https://www.amazon.co.uk/gp/aws/cart/add.html?ASIN.1=B08H93GKNJ&Quantity.1=1',
+			model: 'xbox series x',
+			series: 'xboxsx',
+			url: 'https://www.amazon.co.uk/dp/B08H93GKNJ'
+		},
+		{
+			brand: 'microsoft',
+			cartUrl:
+				'https://www.amazon.co.uk/gp/aws/cart/add.html?ASIN.1=B08GD9MNZB&Quantity.1=1',
+			model: 'xbox series s',
+			series: 'xboxss',
+			url: 'https://www.amazon.co.uk/dp/B08GD9MNZB'
 		}
 	],
 	linksBuilder: {

--- a/src/store/model/computeruniverse.ts
+++ b/src/store/model/computeruniverse.ts
@@ -13,6 +13,10 @@ export const Computeruniverse: Store = {
 		maxPrice: {
 			container: '.product-price',
 			euroFormat: true
+		},
+		outOfStock: {
+			container: '.availability',
+			text: ['nicht verfügbar']
 		}
 	},
 	links: [
@@ -552,6 +556,20 @@ export const Computeruniverse: Store = {
 			series: 'ryzen5950',
 			url:
 				'https://www.computeruniverse.net/de/amd-ryzen-9-5950x-box-ohne-kuehler'
+		},
+		{
+			brand: 'sony',
+			model: 'ps5 console',
+			series: 'sonyps5c',
+			url:
+				'https://www.computeruniverse.net/de/sony-playstation-5-weiss-schwarz-825gb-ssd'
+		},
+		{
+			brand: 'sony',
+			model: 'ps5 digital',
+			series: 'sonyps5de',
+			url:
+				'https://www.computeruniverse.net/de/sony-playstation-5-digital-edition-weiss-schwarz-825gb-ssd'
 		}
 	],
 	name: 'computeruniverse'

--- a/src/store/model/cyberport.ts
+++ b/src/store/model/cyberport.ts
@@ -117,6 +117,30 @@ export const Cyberport: Store = {
 			model: '5950x',
 			series: 'ryzen5950',
 			url: 'https://www.cyberport.de?DEEP=2001-71l'
+		},
+		{
+			brand: 'microsoft',
+			model: 'xbox series x',
+			series: 'xboxsx',
+			url: 'https://www.alternate.de/product/1675115'
+		},
+		{
+			brand: 'microsoft',
+			model: 'xbox series s',
+			series: 'xboxss',
+			url: 'https://www.alternate.de/product/1675117'
+		},
+		{
+			brand: 'sony',
+			model: 'ps5 console',
+			series: 'sonyps5c',
+			url: 'https://www.alternate.de/product/1651220'
+		},
+		{
+			brand: 'sony',
+			model: 'ps5 digital',
+			series: 'sonyps5de',
+			url: 'https://www.alternate.de/product/1651221'
 		}
 	],
 	name: 'cyberport'

--- a/src/store/model/mediamarkt.ts
+++ b/src/store/model/mediamarkt.ts
@@ -249,6 +249,18 @@ export const Mediamarkt: Store = {
 			model: 'ps5 digital',
 			series: 'sonyps5de',
 			url: 'https://www.mediamarkt.de/de/product/-2661939.html'
+		},
+		{
+			brand: 'microsoft',
+			model: 'xbox series x',
+			series: 'xboxsx',
+			url: 'https://www.mediamarkt.de/de/product/-2677360.html'
+		},
+		{
+			brand: 'microsoft',
+			model: 'xbox series s',
+			series: 'xboxss',
+			url: 'https://www.mediamarkt.de/de/product/-2677359.html'
 		}
 	],
 	name: 'mediamarkt'

--- a/src/store/model/saturn.ts
+++ b/src/store/model/saturn.ts
@@ -10,10 +10,16 @@ export const Saturn: Store = {
 			container: 'span[font-family="price"]',
 			euroFormat: false // Note: Saturn uses non-euroFromat as price seperator
 		},
-		outOfStock: {
-			container: '#root',
-			text: ['dieser artikel ist aktuell nicht verfügbar.']
-		}
+		outOfStock: [
+			{
+				container: '#root',
+				text: ['dieser artikel ist aktuell nicht verfügbar.']
+			},
+			{
+				container: '#root',
+				text: ['leider keine Lieferung möglich']
+			}
+		]
 	},
 	links: [
 		{
@@ -171,6 +177,18 @@ export const Saturn: Store = {
 			model: 'ps5 digital',
 			series: 'sonyps5de',
 			url: 'https://www.saturn.de/de/product/-2661939.html'
+		},
+		{
+			brand: 'microsoft',
+			model: 'xbox series x',
+			series: 'xboxsx',
+			url: 'https://www.saturn.de/de/product/-2677360.html'
+		},
+		{
+			brand: 'microsoft',
+			model: 'xbox series s',
+			series: 'xboxss',
+			url: 'https://www.saturn.de/de/product/-2677359.html'
 		}
 	],
 	name: 'saturn'


### PR DESCRIPTION
<!-- Please use Conventional Commits to label your title -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/ -->
<!-- Example: feat: allow provided config object to extend other configs  -->

### Description
Update Alternate, Amazon DE, Amazon ES, Amazon FR, Amazon UK, Computeruniverse, Cyberport, Mediamarkt, Saturn urls.
Includes all urls for PS5 digital or disc version, XBox Series X and XBox Series S whenever found.
Update outOfStock identificator for Alternate, Amazon DE, Amazon ES, Amazon FR, Computeruniverse and Saturn.

<!-- Fixes #(issue) -->
<!-- Please also include relevant motivation and context. -->

### Testing

<!-- Please describe the tests that you ran to verify your changes. -->
<!-- Provide instructions so we can reproduce. -->
<!-- Please also list any relevant details for your test configuration -->

### New dependencies

<!-- List any dependencies that are required for this change. -->
<!-- Otherwise, delete section. -->
