### PR TITLE
dics: correct model values for xbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ environment variables are **optional**._
 | `gigabyte` | `aorus master`, `aorus xtreme`, `eagle`, `eagle oc`, `gaming`, `gaming oc`, `turbo`, `vision`, `vision oc` |
 | `inno3d` | `gaming x3`, `ichill x3`, `ichill x4`, `twin x2 oc` |
 | `kfa2` | `sg`, `sg oc` |
-| `microsoft` | `xboxsx`, `xboxss` |
+| `microsoft` | `xbox series x`, `xbox series s` |
 | `msi` | `gaming x trio`, `ventus 2x oc`, `ventus 3x`, `ventus 3x oc` |
 | `nvidia` | `founders edition` |
 | `palit` | `gamerock oc`, `gaming pro`, `gaming pro oc` |


### PR DESCRIPTION
### Description

The xbox model values for the environment variables are currently provided as `xboxsx` and `xboxss`. These are incorrect. This branch updates the `README.md` file to correct these values as follows: `xbox series x` and `xbox series s`.

### Testing

<!-- Please describe the tests that you ran to verify your changes. -->
- Started and ran `streetmerchant` with the following environment variable as described in the current README.md:
```SHOW_ONLY_MODELS="xboxsx,xboxss"```
- The logs did not provide any reporting on xbox devices
- Started and ran `streetmerchant` with the following environment variable as a hunch:
```SHOW_ONLY_MODELS="xbox series x,xbox series s"```
- This provided reporting on both xbox devices

Enviroment [`.env`] file used:
```
ASCII_BANNER=""
ASCII_COLOR=""
COUNTRY="usa"
SHOW_ONLY_BRANDS="microsoft"
SHOW_ONLY_MODELS="xbox series x,xbox series s"
SHOW_ONLY_SERIES="xboxsx,xboxss"
STORES="amazon,bestbuy,walmart,target,playstation,newegg"
OPEN_BROWSER="true"
DESKTOP_NOTIFICATIONS="false"
```

### New dependencies

None.
