### PR TITLE
fix(bestbuy-ca): replace old evga xc3 ultra

### DIFF
--- a/src/store/model/bestbuy-ca.ts
+++ b/src/store/model/bestbuy-ca.ts
@@ -39,7 +39,7 @@ export const BestBuyCa: Store = {
 			model: 'xc3 ultra',
 			series: '3080',
 			url:
-				'https://www.bestbuy.ca/en-ca/product/evga-geforce-rtx-3080-xc3-ultra-gaming-10gb-gddr6x-video-card/14961449?intl=nosplash'
+				'https://www.bestbuy.ca/en-ca/product/evga-geforce-rtx-3080-xc3-ultra-gaming-10gb-gddr6x-video-card/15084753?intl=nosplash'
 		},
 		{
 			brand: 'asus',


### PR DESCRIPTION

### Description

I've been mainly using this tool to search for an EVGA XC3 3080 in Canada. A few times I noticed that while other resources such as twitter and /r/bapcsalescanada notified stock for this item, street merchant never caught it even though it was running. At first I figured it must have been some latency or another issue.

However, it has come to my attention that bestbuy.ca has two links for this product:

https://www.bestbuy.ca/en-ca/product/evga-geforce-rtx-3080-xc3-ultra-gaming-10gb-gddr6x-video-card-english/14961449

https://www.bestbuy.ca/en-ca/product/evga-geforce-rtx-3080-xc3-ultra-gaming-10gb-gddr6x-video-card/15084753?intl=nosplash

The first link is what is currently stored in the codebase. However, the following resources suggest that it is the second link that is seeing restocking. These are just a few of many different restocks that have occurred, all pointing to the second link:
 
https://www.reddit.com/r/bapcsalescanada/comments/k2arsv/gpu_evga_geforce_rtx_3080_xc3_ultra_gaming_10gb/
https://www.reddit.com/r/bapcsalescanada/comments/k0w9ac/gpu_evga_geforce_rtx_3080_xc3_ultra_gaming_10gb/
https://www.reddit.com/r/bapcsalescanada/comments/jos7m2/gpu_evga_geforce_rtx_3080_xc3_ultra_gaming_10gb/




