### PR TITLE
chore(zotac): add 3060ti, 3070

### DIFF
--- a/src/store/model/zotac.ts
+++ b/src/store/model/zotac.ts
@@ -36,6 +36,20 @@ export const Zotac: Store = {
 		},
 		{
 			brand: 'zotac',
+			model: 'twin edge',
+			series: '3070',
+			url:
+				'https://store.zotac.com/zotac-gaming-geforce-rtx-3070-twin-edge-zt-a30700e-10p'
+		},
+		{
+			brand: 'zotac',
+			model: 'twin edge oc',
+			series: '3070',
+			url:
+				'https://store.zotac.com/zotac-gaming-geforce-rtx-3070-twin-edge-oc-zt-a30700h-10p'
+		},
+		{
+			brand: 'zotac',
 			model: 'trinity',
 			series: '3080',
 			url:

--- a/src/store/model/zotac.ts
+++ b/src/store/model/zotac.ts
@@ -22,6 +22,20 @@ export const Zotac: Store = {
 		},
 		{
 			brand: 'zotac',
+			model: 'twin edge',
+			series: '3060ti',
+			url:
+				'https://store.zotac.com/zotac-gaming-geforce-rtx-3060-ti-twin-edge-zt-a30610e-10m'
+		},
+		{
+			brand: 'zotac',
+			model: 'twin edge oc',
+			series: '3060ti',
+			url:
+				'https://store.zotac.com/zotac-gaming-geforce-rtx-3060-ti-twin-edge-oc-zt-a30610h-10m'
+		},
+		{
+			brand: 'zotac',
 			model: 'trinity',
 			series: '3080',
 			url:


### PR DESCRIPTION
### Description

Adds the RTX 3060 Ti and 3070 cards from the Zotac Online Store.

### Testing

1. Ran tracking with `STORES=zotac` and `SHOW_ONLY_SERIES=3060ti,3070`.
2. Verified `OUT OF STOCK` response. 
