### PR TITLE
feat(store): add Otto

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ environment variables are **optional**._
 | Nvidia | `nvidia`|
 | Nvidia (API) | `nvidia-api`|
 | Office Depot | `officedepot`|
+| Otto | `otto`|
 | Overclockers (UK) | `overclockers`|
 | PCComponentes (ES) | `pccomponentes`|
 | PlayStation | `playstation`|

--- a/src/store/model/index.ts
+++ b/src/store/model/index.ts
@@ -57,6 +57,7 @@ import {Novatech} from './novatech';
 import {Nvidia} from './nvidia';
 import {NvidiaApi} from './nvidia-api';
 import {OfficeDepot} from './officedepot';
+import {Otto} from './otto';
 import {Overclockers} from './overclockers';
 import {PCComponentes} from './pccomponentes';
 import {PlayStation} from './playstation';
@@ -136,6 +137,7 @@ export const storeList = new Map([
 	[Nvidia.name, Nvidia],
 	[NvidiaApi.name, NvidiaApi],
 	[OfficeDepot.name, OfficeDepot],
+	[Otto.name, Otto],
 	[Overclockers.name, Overclockers],
 	[PCComponentes.name, PCComponentes],
 	[PlayStation.name, PlayStation],

--- a/src/store/model/otto.ts
+++ b/src/store/model/otto.ts
@@ -1,0 +1,66 @@
+import {Store} from './store';
+
+export const Otto: Store = {
+	labels: {
+		inStock: [
+			{
+				container:
+					'button.prd_ordering__button.p_btn150--1st.js_product_addToBasket',
+				text: ['In den Warenkorb']
+			}
+		],
+		maxPrice: {
+			container: '#normalPriceAmount',
+			euroFormat: false
+		},
+		outOfStock: {
+			container: 'div.p_message.p_message--hint > strong',
+			text: ['Deinen gewünschten Artikel können wir leider nicht mehr liefern']
+		}
+	},
+	links: [
+		{
+			brand: 'test:brand',
+			model: 'test:model',
+			series: 'test:series',
+			url:
+				'https://www.otto.de/p/playstation-5-medienfernbedienung-1170617135#variationId=1170617136'
+		},
+		{
+			brand: 'sony',
+			model: 'ps5 console',
+			series: 'sonyps5c',
+			url:
+				'https://www.otto.de/p/playstation-5-1136008456/#variationId=1136008459'
+		},
+		{
+			brand: 'sony',
+			model: 'ps5 console',
+			series: 'sonyps5c',
+			url:
+				'https://www.otto.de/p/playstation-5-1154028000#variationId=1154028001'
+		},
+		{
+			brand: 'sony',
+			model: 'ps5 digital',
+			series: 'sonyps5de',
+			url:
+				'https://www.otto.de/p/playstation-5-digital-edition-1161042793#variationId=1161042794'
+		},
+		{
+			brand: 'microsoft',
+			model: 'xbox series s',
+			series: 'xboxss',
+			url:
+				'https://www.otto.de/p/xbox-series-s-1229056876/#variationId=1229056877'
+		},
+		{
+			brand: 'microsoft',
+			model: 'xbox series x',
+			series: 'xboxsx',
+			url:
+				'https://www.otto.de/p/xbox-series-x-1229057353#variationId=1229057354'
+		}
+	],
+	name: 'otto'
+};


### PR DESCRIPTION
<!-- Please use Conventional Commits to label your title -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/ -->
<!-- Example: feat: allow provided config object to extend other configs  -->

### Description
Add support for Otto. Allow checking of PS5 disc and digital version availability, as well as XBox Series X and S.
Two PS5 disc version urls are included as they take the sale url offline once the item is sold out, so I couldn't test out which is the current url.
<!-- Fixes #(issue) -->
<!-- Please also include relevant motivation and context. -->

### Testing

<!-- Please describe the tests that you ran to verify your changes. -->
<!-- Provide instructions so we can reproduce. -->
<!-- Please also list any relevant details for your test configuration -->

### New dependencies

<!-- List any dependencies that are required for this change. -->
<!-- Otherwise, delete section. -->
