### PR TITLE
chore(amazon): adds most available AIB cards

### DIFF
--- a/src/store/model/amazon.ts
+++ b/src/store/model/amazon.ts
@@ -447,12 +447,60 @@ export const Amazon: Store = {
 			url: 'https://www.amazon.com/dp/B08MVC76SR'
 		},
 		{
+			brand: 'sapphire',
+			cartUrl:
+				'https://www.amazon.com/gp/aws/cart/add.html?ASIN.1=B08NXXT7WN&Quantity.1=1',
+			model: 'nitro+',
+			series: 'rx6800xt',
+			url: 'https://www.amazon.com/dp/B08NXXT7WN'
+		},
+		{
+			brand: 'sapphire',
+			cartUrl:
+				'https://www.amazon.com/gp/aws/cart/add.html?ASIN.1=B08NXYNLMR&Quantity.1=1',
+			model: 'pulse',
+			series: 'rx6800xt',
+			url: 'https://www.amazon.com/dp/B08NXYNLMR'
+		},
+		{
+			brand: 'sapphire',
+			cartUrl:
+				'https://www.amazon.com/gp/aws/cart/add.html?ASIN.1=B08NXVNMPQ&Quantity.1=1',
+			model: 'nitro+',
+			series: 'rx6800xt',
+			url: 'https://www.amazon.com/dp/B08NXVNMPQ'
+		},
+		{
 			brand: 'xfx',
 			cartUrl:
 				'https://www.amazon.com/gp/aws/cart/add.html?ASIN.1=B08N6ZLX9B&Quantity.1=1',
 			model: 'amd reference',
 			series: 'rx6800xt',
 			url: 'https://www.amazon.com/dp/B08N6ZLX9B'
+		},
+		{
+			brand: 'xfx',
+			cartUrl:
+				'https://www.amazon.com/gp/aws/cart/add.html?ASIN.1=B08NX14LV1&Quantity.1=1',
+			model: 'merc',
+			series: 'rx6800xt',
+			url: 'https://www.amazon.com/dp/B08NX14LV1'
+		},
+		{
+			brand: 'xfx',
+			cartUrl:
+				'https://www.amazon.com/gp/aws/cart/add.html?ASIN.1=B08NN76VJD&Quantity.1=1',
+			model: 'amd reference',
+			series: 'rx6800',
+			url: 'https://www.amazon.com/dp/B08NN76VJD'
+		},
+		{
+			brand: 'xfx',
+			cartUrl:
+				'https://www.amazon.com/gp/aws/cart/add.html?ASIN.1=B08P5YFZCY&Quantity.1=1',
+			model: 'merc',
+			series: 'rx6800',
+			url: 'https://www.amazon.com/dp/B08P5YFZCY'
 		},
 		{
 			brand: 'powercolor',
@@ -469,6 +517,46 @@ export const Amazon: Store = {
 			model: 'amd reference',
 			series: 'rx6800',
 			url: 'https://www.amazon.com/dp/B08MVCLBWK'
+		},
+		{
+			brand: 'sapphire',
+			cartUrl:
+				'https://www.amazon.com/gp/aws/cart/add.html?ASIN.1=B08NXZSPMY&Quantity.1=1',
+			model: 'nitro+',
+			series: 'rx6800',
+			url: 'https://www.amazon.com/dp/B08NXZSPMY'
+		},
+		{
+			brand: 'sapphire',
+			cartUrl:
+				'https://www.amazon.com/gp/aws/cart/add.html?ASIN.1=B08NXYBVDB&Quantity.1=1',
+			model: 'pulse',
+			series: 'rx6800',
+			url: 'https://www.amazon.com/dp/B08NXYBVDB'
+		},
+		{
+			brand: 'asus',
+			cartUrl:
+				'https://www.amazon.com/gp/aws/cart/add.html?ASIN.1=B08NWJ29NB&Quantity.1=1',
+			model: 'strix oc',
+			series: 'rx6800',
+			url: 'https://www.amazon.com/dp/B08NWJ29NB'
+		},
+		{
+			brand: 'asus',
+			cartUrl:
+				'https://www.amazon.com/gp/aws/cart/add.html?ASIN.1=B08P3YT3MY&Quantity.1=1',
+			model: 'tuf oc',
+			series: 'rx6800',
+			url: 'https://www.amazon.com/dp/B08P3YT3MY'
+		},
+		{
+			brand: 'asus',
+			cartUrl:
+				'https://www.amazon.com/gp/aws/cart/add.html?ASIN.1=B08NWHKGS9&Quantity.1=1',
+			model: 'strix lc',
+			series: 'rx6800xt',
+			url: 'https://www.amazon.com/dp/B08NWHKGS9'
 		},
 		{
 			brand: 'sony',

--- a/src/store/model/bestbuy.ts
+++ b/src/store/model/bestbuy.ts
@@ -388,7 +388,7 @@ export const BestBuy: Store = {
 		{
 			brand: 'msi',
 			model: 'amd reference',
-			series: 'rx6800xt',
+			series: 'rx6800',
 			url:
 				'https://www.bestbuy.com/site/msi-radeon-rx-6800-16g-16gb-gddr6-pci-express-4-0-graphics-card-black-black/6441020.p?skuId=6441020'
 		},

--- a/src/store/model/store.ts
+++ b/src/store/model/store.ts
@@ -94,6 +94,7 @@ export type Model =
 	| 'phoenix'
 	| 'ps5 console'
 	| 'ps5 digital'
+	| 'pulse'
 	| 'red devil'
 	| 'sg oc'
 	| 'sg'


### PR DESCRIPTION
<!-- Please use Conventional Commits to label your title -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/ -->
<!-- Example: feat: allow provided config object to extend other configs  -->

### Description
This pull request addresses and fully resolves #1098 and resolves #1160. This also adds the missing required AIB model to store.ts. This also addresses an issue in bestbuy.ts where an rx6800 card was reporting as an rx6800xt. 