### PR TITLE
fix(bestbuy-ca): model always indicating in stock

### DIFF
--- a/src/store/model/bestbuy-ca.ts
+++ b/src/store/model/bestbuy-ca.ts
@@ -1,170 +1,170 @@
-import { Store } from "./store";
+import {Store} from './store';
 
 export const BestBuyCa: Store = {
 	labels: {
 		inStock: {
-			container: ".x-checkout-experience-new",
-			text: ["add to cart"],
+			container: '.x-checkout-experience-new',
+			text: ['add to cart']
 		},
 		maxPrice: {
 			container:
 				'div[class^="productPricingContainer"] span[class^="screenReaderOnly_"',
-			euroFormat: false,
+			euroFormat: false
 		},
 		outOfStock: {
-			container: "button.addToCartButton.disabled_XY3i_",
-			text: ["Add to Cart"],
-		},
+			container: 'button.addToCartButton.disabled_XY3i_',
+			text: ['Add to Cart']
+		}
 	},
 	links: [
 		{
-			brand: "test:brand",
-			model: "test:model",
-			series: "test:series",
+			brand: 'test:brand',
+			model: 'test:model',
+			series: 'test:series',
 			url:
-				"https://www.bestbuy.ca/en-ca/product/evga-geforce-gtx-1660-xc-ultra-6gb-gddr5-video-card/14119081?intl=nosplash",
+				'https://www.bestbuy.ca/en-ca/product/evga-geforce-gtx-1660-xc-ultra-6gb-gddr5-video-card/14119081?intl=nosplash'
 		},
 		{
-			brand: "msi",
-			model: "ventus 2x oc",
-			series: "3060ti",
+			brand: 'msi',
+			model: 'ventus 2x oc',
+			series: '3060ti',
 			url:
-				"https://www.bestbuy.ca/en-ca/product/msi-nvidia-geforce-rtx-3060-ti-ventus-2x-oc-8gb-gddr6-video-card/15178453?intl=nosplash",
+				'https://www.bestbuy.ca/en-ca/product/msi-nvidia-geforce-rtx-3060-ti-ventus-2x-oc-8gb-gddr6-video-card/15178453?intl=nosplash'
 		},
 		{
-			brand: "nvidia",
-			model: "founders edition",
-			series: "3060ti",
+			brand: 'nvidia',
+			model: 'founders edition',
+			series: '3060ti',
 			url:
-				"https://www.bestbuy.ca/en-ca/product/nvidia-geforce-rtx-3060-ti-8gb-gddr6-video-card/15166285?intl=nosplash",
+				'https://www.bestbuy.ca/en-ca/product/nvidia-geforce-rtx-3060-ti-8gb-gddr6-video-card/15166285?intl=nosplash'
 		},
 		{
-			brand: "zotac",
-			model: "twin edge oc",
-			series: "3060ti",
+			brand: 'zotac',
+			model: 'twin edge oc',
+			series: '3060ti',
 			url:
-				"https://www.bestbuy.ca/en-ca/product/zotac-geforce-rtx-3060-ti-twin-edge-oc-8gb-gddr6-video-card/15178452?intl=nosplash",
+				'https://www.bestbuy.ca/en-ca/product/zotac-geforce-rtx-3060-ti-twin-edge-oc-8gb-gddr6-video-card/15178452?intl=nosplash'
 		},
 		{
-			brand: "zotac",
-			model: "twin edge",
-			series: "3060ti",
+			brand: 'zotac',
+			model: 'twin edge',
+			series: '3060ti',
 			url:
-				"https://www.bestbuy.ca/en-ca/product/zotac-geforce-rtx-3060-ti-twin-edge-8gb-gddr6-video-card/15178583?intl=nosplash",
+				'https://www.bestbuy.ca/en-ca/product/zotac-geforce-rtx-3060-ti-twin-edge-8gb-gddr6-video-card/15178583?intl=nosplash'
 		},
 		{
-			brand: "evga",
-			model: "ftw3 ultra",
-			series: "3060ti",
+			brand: 'evga',
+			model: 'ftw3 ultra',
+			series: '3060ti',
 			url:
-				"https://www.bestbuy.ca/en-ca/product/evga-geforce-rtx-3060-ti-ftw3-ultra-8gb-gddr6-video-card/15200164?intl=nosplash",
+				'https://www.bestbuy.ca/en-ca/product/evga-geforce-rtx-3060-ti-ftw3-ultra-8gb-gddr6-video-card/15200164?intl=nosplash'
 		},
 		{
-			brand: "zotac",
-			model: "trinity",
-			series: "3080",
+			brand: 'zotac',
+			model: 'trinity',
+			series: '3080',
 			url:
-				"https://www.bestbuy.ca/en-ca/product/zotac-geforce-rtx-3080-trinity-10gb-gddr6x-video-card/14953249?intl=nosplash",
+				'https://www.bestbuy.ca/en-ca/product/zotac-geforce-rtx-3080-trinity-10gb-gddr6x-video-card/14953249?intl=nosplash'
 		},
 		{
-			brand: "msi",
-			model: "ventus 3x",
-			series: "3080",
+			brand: 'msi',
+			model: 'ventus 3x',
+			series: '3080',
 			url:
-				"https://www.bestbuy.ca/en-ca/product/msi-nvidia-geforce-rtx-3080-ventus-3x-10gb-gddr6x-video-card/14950588?intl=nosplash",
+				'https://www.bestbuy.ca/en-ca/product/msi-nvidia-geforce-rtx-3080-ventus-3x-10gb-gddr6x-video-card/14950588?intl=nosplash'
 		},
 		{
-			brand: "evga",
-			model: "xc3 ultra",
-			series: "3080",
+			brand: 'evga',
+			model: 'xc3 ultra',
+			series: '3080',
 			url:
-				"https://www.bestbuy.ca/en-ca/product/evga-geforce-rtx-3080-xc3-ultra-gaming-10gb-gddr6x-video-card/15084753?intl=nosplash",
+				'https://www.bestbuy.ca/en-ca/product/evga-geforce-rtx-3080-xc3-ultra-gaming-10gb-gddr6x-video-card/15084753?intl=nosplash'
 		},
 		{
-			brand: "asus",
-			model: "tuf",
-			series: "3080",
+			brand: 'asus',
+			model: 'tuf',
+			series: '3080',
 			url:
-				"https://www.bestbuy.ca/en-ca/product/asus-tuf-gaming-geforce-rtx-3080-10gb-gddr6x-video-card/14953248?intl=nosplash",
+				'https://www.bestbuy.ca/en-ca/product/asus-tuf-gaming-geforce-rtx-3080-10gb-gddr6x-video-card/14953248?intl=nosplash'
 		},
 		{
-			brand: "asus",
-			model: "strix",
-			series: "3080",
+			brand: 'asus',
+			model: 'strix',
+			series: '3080',
 			url:
-				"https://www.bestbuy.ca/en-ca/product/asus-rog-strix-geforce-rtx-3080-10gb-gddr6x-video-card/14954116?intl=nosplash",
+				'https://www.bestbuy.ca/en-ca/product/asus-rog-strix-geforce-rtx-3080-10gb-gddr6x-video-card/14954116?intl=nosplash'
 		},
 		{
-			brand: "zotac",
-			model: "trinity",
-			series: "3090",
+			brand: 'zotac',
+			model: 'trinity',
+			series: '3090',
 			url:
-				"https://www.bestbuy.ca/en-ca/product/zotac-geforce-rtx-3090-trinity-24gb-gddr6x-video-card/14953250?intl=nosplash",
+				'https://www.bestbuy.ca/en-ca/product/zotac-geforce-rtx-3090-trinity-24gb-gddr6x-video-card/14953250?intl=nosplash'
 		},
 		{
-			brand: "asus",
-			model: "tuf",
-			series: "3090",
+			brand: 'asus',
+			model: 'tuf',
+			series: '3090',
 			url:
-				"https://www.bestbuy.ca/en-ca/product/asus-tuf-gaming-geforce-rtx-3090-24gb-gddr6x-video-card/14953247?intl=nosplash",
+				'https://www.bestbuy.ca/en-ca/product/asus-tuf-gaming-geforce-rtx-3090-24gb-gddr6x-video-card/14953247?intl=nosplash'
 		},
 		{
-			brand: "asus",
-			model: "strix",
-			series: "3090",
+			brand: 'asus',
+			model: 'strix',
+			series: '3090',
 			url:
-				"https://www.bestbuy.ca/en-ca/product/asus-rog-strix-geforce-rtx-3090-24gb-gddr6x-video-card/14954117?intl=nosplash",
+				'https://www.bestbuy.ca/en-ca/product/asus-rog-strix-geforce-rtx-3090-24gb-gddr6x-video-card/14954117?intl=nosplash'
 		},
 		{
-			brand: "msi",
-			model: "ventus 3x",
-			series: "3090",
+			brand: 'msi',
+			model: 'ventus 3x',
+			series: '3090',
 			url:
-				"https://www.bestbuy.ca/en-ca/product/msi-nvidia-geforce-rtx-3090-ventus-3x-oc-24gb-gddr6x-video-card/14966477?intl=nosplash",
+				'https://www.bestbuy.ca/en-ca/product/msi-nvidia-geforce-rtx-3090-ventus-3x-oc-24gb-gddr6x-video-card/14966477?intl=nosplash'
 		},
 		{
-			brand: "msi",
-			model: "ventus 3x",
-			series: "3070",
+			brand: 'msi',
+			model: 'ventus 3x',
+			series: '3070',
 			url:
-				"https://www.bestbuy.ca/en-ca/product/msi-nvidia-geforce-rtx-3070-ventus-3x-oc-8gb-gddr6x-video-card/15038016?intl=nosplash",
+				'https://www.bestbuy.ca/en-ca/product/msi-nvidia-geforce-rtx-3070-ventus-3x-oc-8gb-gddr6x-video-card/15038016?intl=nosplash'
 		},
 		{
-			brand: "zotac",
-			model: "twin edge oc",
-			series: "3070",
+			brand: 'zotac',
+			model: 'twin edge oc',
+			series: '3070',
 			url:
-				"https://www.bestbuy.ca/en-ca/product/zotac-nvidia-geforce-rtx-3070-twin-edge-oc-8gb-gddr6x-video-card/15000078?intl=nosplash",
+				'https://www.bestbuy.ca/en-ca/product/zotac-nvidia-geforce-rtx-3070-twin-edge-oc-8gb-gddr6x-video-card/15000078?intl=nosplash'
 		},
 		{
-			brand: "zotac",
-			model: "twin edge",
-			series: "3070",
+			brand: 'zotac',
+			model: 'twin edge',
+			series: '3070',
 			url:
-				"https://www.bestbuy.ca/en-ca/product/zotac-nvidia-geforce-rtx-3070-twin-edge-8gb-gddr6x-video-card/15000079?intl=nosplash",
+				'https://www.bestbuy.ca/en-ca/product/zotac-nvidia-geforce-rtx-3070-twin-edge-8gb-gddr6x-video-card/15000079?intl=nosplash'
 		},
 		{
-			brand: "nvidia",
-			model: "founders edition",
-			series: "3070",
+			brand: 'nvidia',
+			model: 'founders edition',
+			series: '3070',
 			url:
-				"https://www.bestbuy.ca/en-ca/product/nvidia-geforce-rtx-3070-8gb-gddr6-video-card-only-at-best-buy/15078017?intl=nosplash",
+				'https://www.bestbuy.ca/en-ca/product/nvidia-geforce-rtx-3070-8gb-gddr6-video-card-only-at-best-buy/15078017?intl=nosplash'
 		},
 		{
-			brand: "sony",
-			model: "ps5 console",
-			series: "sonyps5c",
+			brand: 'sony',
+			model: 'ps5 console',
+			series: 'sonyps5c',
 			url:
-				"https://www.bestbuy.ca/en-ca/product/playstation-5-console-online-only/14962185?intl=nosplash",
+				'https://www.bestbuy.ca/en-ca/product/playstation-5-console-online-only/14962185?intl=nosplash'
 		},
 		{
-			brand: "sony",
-			model: "ps5 console",
-			series: "sonyps5de",
+			brand: 'sony',
+			model: 'ps5 console',
+			series: 'sonyps5de',
 			url:
-				"https://www.bestbuy.ca/en-ca/product/playstation-5-digital-edition-console-online-only/14962184?intl=nosplash",
-		},
+				'https://www.bestbuy.ca/en-ca/product/playstation-5-digital-edition-console-online-only/14962184?intl=nosplash'
+		}
 	],
-	name: "bestbuy-ca",
-	waitUntil: "domcontentloaded",
+	name: 'bestbuy-ca',
+	waitUntil: 'domcontentloaded'
 };

--- a/src/store/model/bestbuy-ca.ts
+++ b/src/store/model/bestbuy-ca.ts
@@ -1,166 +1,170 @@
-import {Store} from './store';
+import { Store } from "./store";
 
 export const BestBuyCa: Store = {
 	labels: {
 		inStock: {
-			container: '.x-checkout-experience-new',
-			text: ['add to cart']
+			container: ".x-checkout-experience-new",
+			text: ["add to cart"],
 		},
 		maxPrice: {
 			container:
 				'div[class^="productPricingContainer"] span[class^="screenReaderOnly_"',
-			euroFormat: false
-		}
+			euroFormat: false,
+		},
+		outOfStock: {
+			container: "button.addToCartButton.disabled_XY3i_",
+			text: ["Add to Cart"],
+		},
 	},
 	links: [
 		{
-			brand: 'test:brand',
-			model: 'test:model',
-			series: 'test:series',
+			brand: "test:brand",
+			model: "test:model",
+			series: "test:series",
 			url:
-				'https://www.bestbuy.ca/en-ca/product/evga-geforce-gtx-1660-xc-ultra-6gb-gddr5-video-card/14119081?intl=nosplash'
+				"https://www.bestbuy.ca/en-ca/product/evga-geforce-gtx-1660-xc-ultra-6gb-gddr5-video-card/14119081?intl=nosplash",
 		},
 		{
-			brand: 'msi',
-			model: 'ventus 2x oc',
-			series: '3060ti',
+			brand: "msi",
+			model: "ventus 2x oc",
+			series: "3060ti",
 			url:
-				'https://www.bestbuy.ca/en-ca/product/msi-nvidia-geforce-rtx-3060-ti-ventus-2x-oc-8gb-gddr6-video-card/15178453?intl=nosplash'
+				"https://www.bestbuy.ca/en-ca/product/msi-nvidia-geforce-rtx-3060-ti-ventus-2x-oc-8gb-gddr6-video-card/15178453?intl=nosplash",
 		},
 		{
-			brand: 'nvidia',
-			model: 'founders edition',
-			series: '3060ti',
+			brand: "nvidia",
+			model: "founders edition",
+			series: "3060ti",
 			url:
-				'https://www.bestbuy.ca/en-ca/product/nvidia-geforce-rtx-3060-ti-8gb-gddr6-video-card/15166285?intl=nosplash'
+				"https://www.bestbuy.ca/en-ca/product/nvidia-geforce-rtx-3060-ti-8gb-gddr6-video-card/15166285?intl=nosplash",
 		},
 		{
-			brand: 'zotac',
-			model: 'twin edge oc',
-			series: '3060ti',
+			brand: "zotac",
+			model: "twin edge oc",
+			series: "3060ti",
 			url:
-				'https://www.bestbuy.ca/en-ca/product/zotac-geforce-rtx-3060-ti-twin-edge-oc-8gb-gddr6-video-card/15178452?intl=nosplash'
+				"https://www.bestbuy.ca/en-ca/product/zotac-geforce-rtx-3060-ti-twin-edge-oc-8gb-gddr6-video-card/15178452?intl=nosplash",
 		},
 		{
-			brand: 'zotac',
-			model: 'twin edge',
-			series: '3060ti',
+			brand: "zotac",
+			model: "twin edge",
+			series: "3060ti",
 			url:
-				'https://www.bestbuy.ca/en-ca/product/zotac-geforce-rtx-3060-ti-twin-edge-8gb-gddr6-video-card/15178583?intl=nosplash'
+				"https://www.bestbuy.ca/en-ca/product/zotac-geforce-rtx-3060-ti-twin-edge-8gb-gddr6-video-card/15178583?intl=nosplash",
 		},
 		{
-			brand: 'evga',
-			model: 'ftw3 ultra',
-			series: '3060ti',
+			brand: "evga",
+			model: "ftw3 ultra",
+			series: "3060ti",
 			url:
-				'https://www.bestbuy.ca/en-ca/product/evga-geforce-rtx-3060-ti-ftw3-ultra-8gb-gddr6-video-card/15200164?intl=nosplash'
+				"https://www.bestbuy.ca/en-ca/product/evga-geforce-rtx-3060-ti-ftw3-ultra-8gb-gddr6-video-card/15200164?intl=nosplash",
 		},
 		{
-			brand: 'zotac',
-			model: 'trinity',
-			series: '3080',
+			brand: "zotac",
+			model: "trinity",
+			series: "3080",
 			url:
-				'https://www.bestbuy.ca/en-ca/product/zotac-geforce-rtx-3080-trinity-10gb-gddr6x-video-card/14953249?intl=nosplash'
+				"https://www.bestbuy.ca/en-ca/product/zotac-geforce-rtx-3080-trinity-10gb-gddr6x-video-card/14953249?intl=nosplash",
 		},
 		{
-			brand: 'msi',
-			model: 'ventus 3x',
-			series: '3080',
+			brand: "msi",
+			model: "ventus 3x",
+			series: "3080",
 			url:
-				'https://www.bestbuy.ca/en-ca/product/msi-nvidia-geforce-rtx-3080-ventus-3x-10gb-gddr6x-video-card/14950588?intl=nosplash'
+				"https://www.bestbuy.ca/en-ca/product/msi-nvidia-geforce-rtx-3080-ventus-3x-10gb-gddr6x-video-card/14950588?intl=nosplash",
 		},
 		{
-			brand: 'evga',
-			model: 'xc3 ultra',
-			series: '3080',
+			brand: "evga",
+			model: "xc3 ultra",
+			series: "3080",
 			url:
-				'https://www.bestbuy.ca/en-ca/product/evga-geforce-rtx-3080-xc3-ultra-gaming-10gb-gddr6x-video-card/15084753?intl=nosplash'
+				"https://www.bestbuy.ca/en-ca/product/evga-geforce-rtx-3080-xc3-ultra-gaming-10gb-gddr6x-video-card/15084753?intl=nosplash",
 		},
 		{
-			brand: 'asus',
-			model: 'tuf',
-			series: '3080',
+			brand: "asus",
+			model: "tuf",
+			series: "3080",
 			url:
-				'https://www.bestbuy.ca/en-ca/product/asus-tuf-gaming-geforce-rtx-3080-10gb-gddr6x-video-card/14953248?intl=nosplash'
+				"https://www.bestbuy.ca/en-ca/product/asus-tuf-gaming-geforce-rtx-3080-10gb-gddr6x-video-card/14953248?intl=nosplash",
 		},
 		{
-			brand: 'asus',
-			model: 'strix',
-			series: '3080',
+			brand: "asus",
+			model: "strix",
+			series: "3080",
 			url:
-				'https://www.bestbuy.ca/en-ca/product/asus-rog-strix-geforce-rtx-3080-10gb-gddr6x-video-card/14954116?intl=nosplash'
+				"https://www.bestbuy.ca/en-ca/product/asus-rog-strix-geforce-rtx-3080-10gb-gddr6x-video-card/14954116?intl=nosplash",
 		},
 		{
-			brand: 'zotac',
-			model: 'trinity',
-			series: '3090',
+			brand: "zotac",
+			model: "trinity",
+			series: "3090",
 			url:
-				'https://www.bestbuy.ca/en-ca/product/zotac-geforce-rtx-3090-trinity-24gb-gddr6x-video-card/14953250?intl=nosplash'
+				"https://www.bestbuy.ca/en-ca/product/zotac-geforce-rtx-3090-trinity-24gb-gddr6x-video-card/14953250?intl=nosplash",
 		},
 		{
-			brand: 'asus',
-			model: 'tuf',
-			series: '3090',
+			brand: "asus",
+			model: "tuf",
+			series: "3090",
 			url:
-				'https://www.bestbuy.ca/en-ca/product/asus-tuf-gaming-geforce-rtx-3090-24gb-gddr6x-video-card/14953247?intl=nosplash'
+				"https://www.bestbuy.ca/en-ca/product/asus-tuf-gaming-geforce-rtx-3090-24gb-gddr6x-video-card/14953247?intl=nosplash",
 		},
 		{
-			brand: 'asus',
-			model: 'strix',
-			series: '3090',
+			brand: "asus",
+			model: "strix",
+			series: "3090",
 			url:
-				'https://www.bestbuy.ca/en-ca/product/asus-rog-strix-geforce-rtx-3090-24gb-gddr6x-video-card/14954117?intl=nosplash'
+				"https://www.bestbuy.ca/en-ca/product/asus-rog-strix-geforce-rtx-3090-24gb-gddr6x-video-card/14954117?intl=nosplash",
 		},
 		{
-			brand: 'msi',
-			model: 'ventus 3x',
-			series: '3090',
+			brand: "msi",
+			model: "ventus 3x",
+			series: "3090",
 			url:
-				'https://www.bestbuy.ca/en-ca/product/msi-nvidia-geforce-rtx-3090-ventus-3x-oc-24gb-gddr6x-video-card/14966477?intl=nosplash'
+				"https://www.bestbuy.ca/en-ca/product/msi-nvidia-geforce-rtx-3090-ventus-3x-oc-24gb-gddr6x-video-card/14966477?intl=nosplash",
 		},
 		{
-			brand: 'msi',
-			model: 'ventus 3x',
-			series: '3070',
+			brand: "msi",
+			model: "ventus 3x",
+			series: "3070",
 			url:
-				'https://www.bestbuy.ca/en-ca/product/msi-nvidia-geforce-rtx-3070-ventus-3x-oc-8gb-gddr6x-video-card/15038016?intl=nosplash'
+				"https://www.bestbuy.ca/en-ca/product/msi-nvidia-geforce-rtx-3070-ventus-3x-oc-8gb-gddr6x-video-card/15038016?intl=nosplash",
 		},
 		{
-			brand: 'zotac',
-			model: 'twin edge oc',
-			series: '3070',
+			brand: "zotac",
+			model: "twin edge oc",
+			series: "3070",
 			url:
-				'https://www.bestbuy.ca/en-ca/product/zotac-nvidia-geforce-rtx-3070-twin-edge-oc-8gb-gddr6x-video-card/15000078?intl=nosplash'
+				"https://www.bestbuy.ca/en-ca/product/zotac-nvidia-geforce-rtx-3070-twin-edge-oc-8gb-gddr6x-video-card/15000078?intl=nosplash",
 		},
 		{
-			brand: 'zotac',
-			model: 'twin edge',
-			series: '3070',
+			brand: "zotac",
+			model: "twin edge",
+			series: "3070",
 			url:
-				'https://www.bestbuy.ca/en-ca/product/zotac-nvidia-geforce-rtx-3070-twin-edge-8gb-gddr6x-video-card/15000079?intl=nosplash'
+				"https://www.bestbuy.ca/en-ca/product/zotac-nvidia-geforce-rtx-3070-twin-edge-8gb-gddr6x-video-card/15000079?intl=nosplash",
 		},
 		{
-			brand: 'nvidia',
-			model: 'founders edition',
-			series: '3070',
+			brand: "nvidia",
+			model: "founders edition",
+			series: "3070",
 			url:
-				'https://www.bestbuy.ca/en-ca/product/nvidia-geforce-rtx-3070-8gb-gddr6-video-card-only-at-best-buy/15078017?intl=nosplash'
+				"https://www.bestbuy.ca/en-ca/product/nvidia-geforce-rtx-3070-8gb-gddr6-video-card-only-at-best-buy/15078017?intl=nosplash",
 		},
 		{
-			brand: 'sony',
-			model: 'ps5 console',
-			series: 'sonyps5c',
+			brand: "sony",
+			model: "ps5 console",
+			series: "sonyps5c",
 			url:
-				'https://www.bestbuy.ca/en-ca/product/playstation-5-console-online-only/14962185?intl=nosplash'
+				"https://www.bestbuy.ca/en-ca/product/playstation-5-console-online-only/14962185?intl=nosplash",
 		},
 		{
-			brand: 'sony',
-			model: 'ps5 console',
-			series: 'sonyps5de',
+			brand: "sony",
+			model: "ps5 console",
+			series: "sonyps5de",
 			url:
-				'https://www.bestbuy.ca/en-ca/product/playstation-5-digital-edition-console-online-only/14962184?intl=nosplash'
-		}
+				"https://www.bestbuy.ca/en-ca/product/playstation-5-digital-edition-console-online-only/14962184?intl=nosplash",
+		},
 	],
-	name: 'bestbuy-ca',
-	waitUntil: 'domcontentloaded'
+	name: "bestbuy-ca",
+	waitUntil: "domcontentloaded",
 };


### PR DESCRIPTION
### Description

Fixes #1093

It seams that the page changed to always include the "Add to cart button". However, when there is no card in stock, that button is disabled. I used the class applied on the button when there is no items in stock to fix the issue.

### Testing

I tried with the test URL and with some cards that where not in stock. The same class is added to the button when the product is not in stock.

Hope it helps !