### PR TITLE
fix(store): italian store checks

### DIFF
--- a/src/store/model/amazon-it.ts
+++ b/src/store/model/amazon-it.ts
@@ -5,7 +5,9 @@ export const AmazonIt: Store = {
 	labels: {
 		captcha: {
 			container: 'body',
-			text: ['enter the characters you see below']
+			text: [
+				'Inserisci i caratteri visualizzati nello spazio sottostante'
+			]
 		},
 		inStock: {
 			container: '#desktop_buybox',

--- a/src/store/model/eprice.ts
+++ b/src/store/model/eprice.ts
@@ -9,6 +9,10 @@ export const Eprice: Store = {
 		maxPrice: {
 			container: '#PrezzoClasic span[class*="big"]',
 			euroFormat: true
+		},
+		outOfStock: {
+			container: '.dispo',
+			text: ['ESAURITO O FUORI PROD.']
 		}
 	},
 	links: [

--- a/src/store/model/unieuro.ts
+++ b/src/store/model/unieuro.ts
@@ -2,6 +2,10 @@ import {Store} from './store';
 
 export const Unieuro: Store = {
 	labels: {
+		captcha: {
+			container: 'body',
+			text: ['Too Many Requests.']
+		},
 		inStock: {
 			container: '.price-container',
 			text: ['Aggiungi al carrello']


### PR DESCRIPTION
<!-- Please use Conventional Commits to label your title -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/ -->
<!-- Example: feat: allow provided config object to extend other configs  -->

### Description
Fix some issues on some Italian store.
In particular:
- ePrice store sometimes products where show wrongly in stock
- Amazon-it do not correctly see the caption page
- Uniero return a blank page after too many requests

<!-- Fixes #(issue) -->
<!-- Please also include relevant motivation and context. -->

### Test
I used the trick on issue #1194 to always save a screenshot. Maybe it can be useful to have a configuration option to do that.
