### PR TITLE
feat(store): add Megekko

### DIFF
--- a/docs/reference/filter.md
+++ b/docs/reference/filter.md
@@ -81,6 +81,7 @@ Used with the `STORES` variable.
 | Kabum (BR) | `kabum`|
 | Mediamarkt (DE) | `mediamarkt`|
 | Medimax | `medimax`|
+| Megekko (NL) | `megekko`|
 | MemoryExpress (CA) | `memoryexpress`|
 | Micro Center | `microcenter`|
 | Mindfactory (DE) | `mindfactory` |
@@ -138,11 +139,11 @@ Used with the `SHOW_ONLY_BRANDS` and `SHOW_ONLY_MODELS` variables.
 | `corsair` | `750 platinum`, `600 platinum` |
 | `evga` | `ftw3`, `ftw3 ultra`, `xc3`, `xc3 black`, `xc3 ultra` |
 | `gainward` | `phantom gs`, `phoenix`, `phoenix gs`, `phoenix gs oc` |
-| `gigabyte` | `aorus master`, `aorus xtreme`, `eagle`, `eagle oc`, `gaming`, `gaming oc`, `turbo`, `vision`, `vision oc` |
-| `inno3d` | `gaming x3`, `ichill x3`, `ichill x4`, `twin x2 oc` |
+| `gigabyte` | `aorus master`, `aorus xtreme`, `aorus xtreme waterforce`, `eagle`, `eagle oc`, `gaming`, `gaming oc`, `turbo`, `vision`, `vision oc` |
+| `inno3d` | `gaming x3`, `ichill x3`, `ichill x4`, `ichill frostbite`, `twin x2 oc` |
 | `kfa2` | `sg`, `sg oc` |
 | `microsoft` | `xbox series x`, `xbox series s` |
-| `msi` | `gaming x trio`, `ventus 2x oc`, `ventus 3x`, `ventus 3x oc` |
+| `msi` | `gaming x trio`, `suprim x`, `ventus 2x oc`, `ventus 3x`, `ventus 3x oc` |
 | `nvidia` | `founders edition` |
 | `palit` | `gamerock oc`, `gaming pro`, `gaming pro oc` |
 | `pny` | `dual fan`, `xlr8 revel`, `xlr8 uprising` |

--- a/src/store/model/index.ts
+++ b/src/store/model/index.ts
@@ -52,6 +52,7 @@ import {GamestopDE} from './gamestop-de';
 import {Kabum} from './kabum';
 import {Mediamarkt} from './mediamarkt';
 import {Medimax} from './medimax';
+import {Megekko} from './megekko';
 import {MemoryExpress} from './memoryexpress';
 import {MicroCenter} from './microcenter';
 import {Mindfactory} from './mindfactory';
@@ -139,6 +140,7 @@ export const storeList = new Map([
 	[Kabum.name, Kabum],
 	[Mediamarkt.name, Mediamarkt],
 	[Medimax.name, Medimax],
+	[Megekko.name, Megekko],
 	[MemoryExpress.name, MemoryExpress],
 	[MicroCenter.name, MicroCenter],
 	[Mindfactory.name, Mindfactory],

--- a/src/store/model/megekko.ts
+++ b/src/store/model/megekko.ts
@@ -23,24 +23,6 @@ export const Megekko: Store = {
 			url: 'https://www.megekko.nl/product/351421/'
 		},
 		{
-			brand: 'msi',
-			model: 'gaming x trio',
-			series: '3080',
-			url: 'https://www.megekko.nl/product/292742/'
-		},
-		{
-			brand: 'msi',
-			model: 'ventus 3x oc',
-			series: '3080',
-			url: 'https://www.megekko.nl/product/292740/'
-		},
-		{
-			brand: 'msi',
-			model: 'suprim x',
-			series: '3080',
-			url: 'https://www.megekko.nl/product/295473/'
-		},
-		{
 			brand: 'asus',
 			model: 'tuf',
 			series: '3080',
@@ -65,6 +47,36 @@ export const Megekko: Store = {
 			url: 'https://www.megekko.nl/product/1118233/'
 		},
 		{
+			brand: 'evga',
+			model: 'ftw3 ultra',
+			series: '3080',
+			url: 'https://www.megekko.nl/product/1118248/'
+		},
+		{
+			brand: 'evga',
+			model: 'ftw3 ultra',
+			series: '3080',
+			url: 'https://www.megekko.nl/product/1118249/'
+		},
+		{
+			brand: 'evga',
+			model: 'xc3',
+			series: '3080',
+			url: 'https://www.megekko.nl/product/1118247/'
+		},
+		{
+			brand: 'evga',
+			model: 'xc3 ultra',
+			series: '3080',
+			url: 'https://www.megekko.nl/product/1118260/'
+		},
+		{
+			brand: 'evga',
+			model: 'xc3 black',
+			series: '3080',
+			url: 'https://www.megekko.nl/product/1118246/'
+		},
+		{
 			brand: 'gigabyte',
 			model: 'gaming oc',
 			series: '3080',
@@ -75,6 +87,12 @@ export const Megekko: Store = {
 			model: 'vision oc',
 			series: '3080',
 			url: 'https://www.megekko.nl/product/293966/'
+		},
+		{
+			brand: 'gigabyte',
+			model: 'aorus master',
+			series: '3080',
+			url: 'https://www.megekko.nl/product/293965/'
 		},
 		{
 			brand: 'gigabyte',
@@ -90,51 +108,15 @@ export const Megekko: Store = {
 		},
 		{
 			brand: 'gigabyte',
-			model: 'eagle oc',
-			series: '3080',
-			url: 'https://www.megekko.nl/product/292735/'
-		},
-		{
-			brand: 'gigabyte',
-			model: 'aorus master',
-			series: '3080',
-			url: 'https://www.megekko.nl/product/293965/'
-		},
-		{
-			brand: 'evga',
-			model: 'ftw3 ultra',
-			series: '3080',
-			url: 'https://www.megekko.nl/product/1118248/'
-		},
-		{
-			brand: 'evga',
-			model: 'ftw3 ultra',
-			series: '3080',
-			url: 'https://www.megekko.nl/product/1118249/'
-		},
-		{
-			brand: 'evga',
-			model: 'xc3 gaming',
-			series: '3080',
-			url: 'https://www.megekko.nl/product/1118247/'
-		},
-		{
-			brand: 'gigabyte',
 			model: 'eagle',
 			series: '3080',
 			url: 'https://www.megekko.nl/product/1125074/'
 		},
 		{
-			brand: 'evga',
-			model: 'xc3 ultra',
+			brand: 'gigabyte',
+			model: 'eagle oc',
 			series: '3080',
-			url: 'https://www.megekko.nl/product/1118260/'
-		},
-		{
-			brand: 'evga',
-			model: 'xc3 black',
-			series: '3080',
-			url: 'https://www.megekko.nl/product/1118246/'
+			url: 'https://www.megekko.nl/product/292735/'
 		},
 		{
 			brand: 'inno3d',
@@ -153,6 +135,24 @@ export const Megekko: Store = {
 			model: 'ichill x4',
 			series: '3080',
 			url: 'https://www.megekko.nl/product/1118237/'
+		},
+		{
+			brand: 'msi',
+			model: 'gaming x trio',
+			series: '3080',
+			url: 'https://www.megekko.nl/product/292742/'
+		},
+		{
+			brand: 'msi',
+			model: 'ventus 3x oc',
+			series: '3080',
+			url: 'https://www.megekko.nl/product/292740/'
+		},
+		{
+			brand: 'msi',
+			model: 'suprim x',
+			series: '3080',
+			url: 'https://www.megekko.nl/product/295473/'
 		}
 	],
 	name: 'megekko'

--- a/src/store/model/megekko.ts
+++ b/src/store/model/megekko.ts
@@ -1,0 +1,159 @@
+import {Store} from './store';
+
+export const Megekko: Store = {
+	labels: {
+		inStock: {
+			container: '.product-order .text_green',
+			text: ['dag', 'werkdag']
+		},
+		maxPrice: {
+			container: '.col_right_container .euro',
+			euroFormat: false
+		},
+		outOfStock: {
+			container: '.product_detail .text_red',
+			text: ['minimaal 10 dagen']
+		}
+	},
+	links: [
+		{
+			brand: 'test:brand',
+			model: 'test:model',
+			series: 'test:series',
+			url: 'https://www.coolblue.nl/product/826844/'
+		},
+		{
+			brand: 'msi',
+			model: 'gaming x trio',
+			series: '3080',
+			url: 'https://www.megekko.nl/product/292742/'
+		},
+		{
+			brand: 'msi',
+			model: 'ventus 3x oc',
+			series: '3080',
+			url: 'https://www.megekko.nl/product/292740/'
+		},
+		{
+			brand: 'msi',
+			model: 'suprim x',
+			series: '3080',
+			url: 'https://www.megekko.nl/product/295473/'
+		},
+		{
+			brand: 'asus',
+			model: 'tuf',
+			series: '3080',
+			url: 'https://www.megekko.nl/product/1118232/'
+		},
+		{
+			brand: 'asus',
+			model: 'strix',
+			series: '3080',
+			url: 'https://www.megekko.nl/product/1119242/'
+		},
+		{
+			brand: 'asus',
+			model: 'strix oc',
+			series: '3080',
+			url: 'https://www.megekko.nl/product/1119243/'
+		},
+		{
+			brand: 'asus',
+			model: 'tuf oc',
+			series: '3080',
+			url: 'https://www.megekko.nl/product/1118233/'
+		},
+		{
+			brand: 'gigabyte',
+			model: 'gaming oc',
+			series: '3080',
+			url: 'https://www.megekko.nl/product/292736/'
+		},
+		{
+			brand: 'gigabyte',
+			model: 'vision oc',
+			series: '3080',
+			url: 'https://www.megekko.nl/product/293966/'
+		},
+		{
+			brand: 'gigabyte',
+			model: 'aorus xtreme',
+			series: '3080',
+			url: 'https://www.megekko.nl/product/293964/'
+		},
+		{
+			brand: 'gigabyte',
+			model: 'aorus xtreme waterforce',
+			series: '3080',
+			url: 'https://www.megekko.nl/product/296925/'
+		},
+		{
+			brand: 'gigabyte',
+			model: 'eagle oc',
+			series: '3080',
+			url: 'https://www.megekko.nl/product/292735/'
+		},
+		{
+			brand: 'gigabyte',
+			model: 'aorus master',
+			series: '3080',
+			url: 'https://www.megekko.nl/product/293965/'
+		},
+		{
+			brand: 'evga',
+			model: 'ftw3 ultra',
+			series: '3080',
+			url: 'https://www.megekko.nl/product/1118248/'
+		},
+		{
+			brand: 'evga',
+			model: 'ftw3 ultra',
+			series: '3080',
+			url: 'https://www.megekko.nl/product/1118249/'
+		},
+		{
+			brand: 'evga',
+			model: 'xc3 gaming',
+			series: '3080',
+			url: 'https://www.megekko.nl/product/1118247/'
+		},
+		{
+			brand: 'gigabyte',
+			model: 'eagle',
+			series: '3080',
+			url: 'https://www.megekko.nl/product/1125074/'
+		},
+		{
+			brand: 'evga',
+			model: 'xc3 ultra',
+			series: '3080',
+			url: 'https://www.megekko.nl/product/1118260/'
+		},
+		{
+			brand: 'evga',
+			model: 'xc3 black',
+			series: '3080',
+			url: 'https://www.megekko.nl/product/1118246/'
+		},
+		{
+			brand: 'inno3d',
+			model: 'ichill frostbite',
+			series: '3080',
+			url: 'https://www.megekko.nl/product/1125524/'
+		},
+		{
+			brand: 'inno3d',
+			model: 'ichill x3',
+			series: '3080',
+			url: 'https://www.megekko.nl/product/1118236/'
+		},
+		{
+			brand: 'inno3d',
+			model: 'ichill x4',
+			series: '3080',
+			url: 'https://www.megekko.nl/product/1118237/'
+		}
+	],
+	name: 'megekko'
+};

--- a/src/store/model/megekko.ts
+++ b/src/store/model/megekko.ts
@@ -20,7 +20,7 @@ export const Megekko: Store = {
 			brand: 'test:brand',
 			model: 'test:model',
 			series: 'test:series',
-			url: 'https://www.coolblue.nl/product/826844/'
+			url: 'https://www.megekko.nl/product/351421/'
 		},
 		{
 			brand: 'msi',

--- a/src/store/model/store.ts
+++ b/src/store/model/store.ts
@@ -130,7 +130,6 @@ export type Model =
 	| 'xc3 black'
 	| 'xc3 ultra'
 	| 'xc3'
-	| 'xc3 gaming'
 	| 'xlr8 revel'
 	| 'xlr8 uprising';
 

--- a/src/store/model/store.ts
+++ b/src/store/model/store.ts
@@ -64,6 +64,7 @@ export type Model =
 	| 'amp holo'
 	| 'aorus master'
 	| 'aorus xtreme'
+	| 'aorus xtreme waterforce'
 	| 'aorus'
 	| 'challenger'
 	| 'dual fan'
@@ -81,10 +82,12 @@ export type Model =
 	| 'gaming pro'
 	| 'gaming x trio'
 	| 'gaming x3'
+	| 'suprim x'
 	| 'gaming'
 	| 'ichill x2'
 	| 'ichill x3'
 	| 'ichill x4'
+	| 'ichill frostbite'
 	| 'ko'
 	| 'nitro+'
 	| 'nitro oc se'
@@ -127,6 +130,7 @@ export type Model =
 	| 'xc3 black'
 	| 'xc3 ultra'
 	| 'xc3'
+	| 'xc3 gaming'
 	| 'xlr8 revel'
 	| 'xlr8 uprising';
 


### PR DESCRIPTION
feat: Megekko (NL) added to the existing stores.

### Description

- Added 1 new store: Megekko (NL). Currently only products listed are from the RTX 3080 Series.
- Also added a few new models for RTX 3080.