### PR TITLE
chore(amazon): add 3060ti cards

### DIFF
--- a/src/store/model/amazon.ts
+++ b/src/store/model/amazon.ts
@@ -33,6 +33,110 @@ export const Amazon: Store = {
 		{
 			brand: 'asus',
 			cartUrl:
+				'https://www.amazon.com/gp/aws/cart/add.html?ASIN.1=B08P2HBBLX&Quantity.1=1',
+			model: 'dual',
+			series: '3060ti',
+			url: 'https://www.amazon.com/dp/B08P2HBBLX'
+		},
+		{
+			brand: 'gigabyte',
+			cartUrl:
+				'https://www.amazon.com/gp/aws/cart/add.html?ASIN.1=B08NYP7KG6&Quantity.1=1',
+			model: 'gaming oc',
+			series: '3060ti',
+			url: 'https://www.amazon.com/dp/B08NYP7KG6'
+		},
+		{
+			brand: 'gigabyte',
+			cartUrl:
+				'https://www.amazon.com/gp/aws/cart/add.html?ASIN.1=B08NYPLXPJ&Quantity.1=1',
+			model: 'gaming oc',
+			series: '3060ti',
+			url: 'https://www.amazon.com/dp/B08NYPLXPJ'
+		},
+		{
+			brand: 'gigabyte',
+			cartUrl:
+				'https://www.amazon.com/gp/aws/cart/add.html?ASIN.1=B08NYNJ6RC&Quantity.1=1',
+			model: 'eagle',
+			series: '3060ti',
+			url: 'https://www.amazon.com/dp/B08NYNJ6RC'
+		},
+		{
+			brand: 'asus',
+			cartUrl:
+				'https://www.amazon.com/gp/aws/cart/add.html?ASIN.1=B083Z5P6TX&Quantity.1=1',
+			model: 'tuf',
+			series: '3060ti',
+			url: 'https://www.amazon.com/dp/B083Z5P6TX'
+		},
+		{
+			brand: 'msi',
+			cartUrl:
+				'https://www.amazon.com/gp/aws/cart/add.html?ASIN.1=B08P2D3JSG&Quantity.1=1',
+			model: 'gaming x trio',
+			series: '3060ti',
+			url: 'https://www.amazon.com/dp/B08P2D3JSG'
+		},
+		{
+			brand: 'msi',
+			cartUrl:
+				'https://www.amazon.com/gp/aws/cart/add.html?ASIN.1=B08P2DQ28S&Quantity.1=1',
+			model: 'ventus 2x',
+			series: '3060ti',
+			url: 'https://www.amazon.com/dp/B08P2DQ28S'
+		},
+		{
+			brand: 'zotac',
+			cartUrl:
+				'https://www.amazon.com/gp/aws/cart/add.html?ASIN.1=B08P3XJLJJ&Quantity.1=1',
+			model: 'twin edge oc',
+			series: '3060ti',
+			url: 'https://www.amazon.com/dp/B08P3XJLJJ'
+		},
+		{
+			brand: 'zotac',
+			cartUrl:
+				'https://www.amazon.com/gp/aws/cart/add.html?ASIN.1=B08P3V572B&Quantity.1=1',
+			model: 'twin edge',
+			series: '3060ti',
+			url: 'https://www.amazon.com/dp/B08P3V572B'
+		},
+		{
+			brand: 'asus',
+			cartUrl:
+				'https://www.amazon.com/gp/aws/cart/add.html?ASIN.1=B08P2D1JZZ&Quantity.1=1',
+			model: 'ko',
+			series: '3060ti',
+			url: 'https://www.amazon.com/dp/B08P2D1JZZ'
+		},
+		{
+			brand: 'asus',
+			cartUrl:
+				'https://www.amazon.com/gp/aws/cart/add.html?ASIN.1=B083Z7TR8Z&Quantity.1=1',
+			model: 'strix',
+			series: '3060ti',
+			url: 'https://www.amazon.com/dp/B083Z7TR8Z'
+		},
+		{
+			brand: 'evga',
+			cartUrl:
+				'https://www.amazon.com/gp/aws/cart/add.html?ASIN.1=B08P2H5LW2&Quantity.1=1',
+			model: 'ftw3',
+			series: '3060ti',
+			url: 'https://www.amazon.com/dp/B08P2H5LW2'
+		},
+		{
+			brand: 'gigabyte',
+			cartUrl:
+				'https://www.amazon.com/gp/aws/cart/add.html?ASIN.1=B08NYPKW1Z&Quantity.1=1',
+			model: 'eagle oc',
+			series: '3060ti',
+			url: 'https://www.amazon.com/dp/B08NYPKW1Z'
+		},
+		{
+			brand: 'asus',
+			cartUrl:
 				'https://www.amazon.com/gp/aws/cart/add.html?ASIN.1=B08L8LG4M3&Quantity.1=1',
 			model: 'dual',
 			series: '3070',


### PR DESCRIPTION
<!-- Please use Conventional Commits to label your title -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/ -->
<!-- Example: feat: allow provided config object to extend other configs  -->

### Description

added support for 3060ti cards on amazon on amazon.ts 

### Testing

Only modified src/store/model/amazon.ts

### New dependencies

NA
