### PR TITLE
fix(amazon-it): maxPrice selector and links

### DIFF
--- a/src/store/model/amazon-it.ts
+++ b/src/store/model/amazon-it.ts
@@ -20,10 +20,10 @@ export const AmazonIt: Store = {
 		{
 			brand: 'asus',
 			cartUrl:
-				'https://www.amazon.it/gp/aws/cart/add.html?ASIN.1=B07PW9VBK5&Quantity.1=1',
+				'https://www.amazon.it/gp/aws/cart/add.html?ASIN.1=B08KHFZN9P&Quantity.1=1',
 			model: 'dual',
 			series: '3070',
-			url: 'https://www.amazon.it/dp/B07PW9VBK5'
+			url: 'https://www.amazon.it/dp/B08KHFZN9P'
 		},
 		{
 			brand: 'asus',

--- a/src/store/model/amazon-it.ts
+++ b/src/store/model/amazon-it.ts
@@ -12,7 +12,8 @@ export const AmazonIt: Store = {
 			text: ['Aggiungi al carrello']
 		},
 		maxPrice: {
-			container: '#priceblock_ourprice'
+			container: '#priceblock_ourprice',
+			euroFormat: true
 		}
 	},
 	links: [


### PR DESCRIPTION
### Description

Fixes issues #1237 #1238 

The `amazon-it` store is now updated to fix some bugs

- Fixed price parsing using the correct decimal separator
- Fixed an Asus 3070 Dual url, which pointer to an Amazon Fire Stick instead