### PR TITLE
feat(notification): add sound player executable option

### DIFF
--- a/docs/reference/notification.md
+++ b/docs/reference/notification.md
@@ -8,6 +8,7 @@ You can test your notification configuration by running `npm run test:notificati
 |---|---|
 | `DESKTOP_NOTIFICATIONS` | Display desktop notifications using [node-notifier](https://www.npmjs.com/package/node-notifier). |
 | `PLAY_SOUND` | Play this sound notification if a product is found. Relative path accepted, valid formats: wav, mp3, flac, E.g.: `path/to/notification.wav`, [free sounds available](https://notificationsounds.com/) |
+| `SOUND_PLAYER` | Override the default sound player using the specified executable. |
 
 ???+ attention
     If you're on Windows, you must have the proper library to run.

--- a/src/config.ts
+++ b/src/config.ts
@@ -258,7 +258,6 @@ const notifications = {
 		number: envOrArray(process.env.PHONE_NUMBER)
 	},
 	playSound: envOrString(process.env.PLAY_SOUND),
-	soundPlayer: envOrString(process.env.SOUND_PLAYER),
 	pushbullet: envOrString(process.env.PUSHBULLET),
 	pushover: {
 		expire: envOrNumber(process.env.PUSHOVER_EXPIRE),
@@ -271,6 +270,7 @@ const notifications = {
 		channel: envOrString(process.env.SLACK_CHANNEL),
 		token: envOrString(process.env.SLACK_TOKEN)
 	},
+	soundPlayer: envOrString(process.env.SOUND_PLAYER),
 	telegram: {
 		accessToken: envOrString(process.env.TELEGRAM_ACCESS_TOKEN),
 		chatId: envOrArray(process.env.TELEGRAM_CHAT_ID)

--- a/src/config.ts
+++ b/src/config.ts
@@ -258,6 +258,7 @@ const notifications = {
 		number: envOrArray(process.env.PHONE_NUMBER)
 	},
 	playSound: envOrString(process.env.PLAY_SOUND),
+	soundPlayer: envOrString(process.env.SOUND_PLAYER),
 	pushbullet: envOrString(process.env.PUSHBULLET),
 	pushover: {
 		expire: envOrNumber(process.env.PUSHOVER_EXPIRE),

--- a/src/notification/sound.ts
+++ b/src/notification/sound.ts
@@ -6,11 +6,9 @@ import {logger} from '../logger';
 let player: PlaySound;
 
 if (config.notifications.playSound) {
-	if (config.notifications.soundPlayer) {
-		player = playerLib({player: config.notifications.soundPlayer});
-	} else {
-		player = playerLib();
-	}
+	player = config.notifications.soundPlayer
+		? playerLib({player: config.notifications.soundPlayer})
+		: playerLib();
 
 	if (player.player === null) {
 		logger.warn("✖ couldn't find sound player");

--- a/src/notification/sound.ts
+++ b/src/notification/sound.ts
@@ -6,7 +6,11 @@ import {logger} from '../logger';
 let player: PlaySound;
 
 if (config.notifications.playSound) {
-	player = playerLib();
+	if (config.notifications.soundPlayer) {
+		player = playerLib({player: config.notifications.soundPlayer});
+	} else {
+		player = playerLib();
+	}
 
 	if (player.player === null) {
 		logger.warn("✖ couldn't find sound player");

--- a/src/notification/sound.ts
+++ b/src/notification/sound.ts
@@ -7,7 +7,7 @@ let player: PlaySound;
 
 if (config.notifications.playSound) {
 	player = config.notifications.soundPlayer
-		? playerLib({player: config.notifications.soundPlayer})
+		? playerLib({players: [config.notifications.soundPlayer]})
 		: playerLib();
 
 	if (player.player === null) {


### PR DESCRIPTION
<!-- Please use Conventional Commits to label your title -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/ -->
<!-- Example: feat: allow provided config object to extend other configs  -->

### Description

Allows the default sound player to be overridden. I was having trouble on Ubuntu with the default player which sound-player chose.

### Testing

Ran locally

### New dependencies

None
