### PR TITLE
fix: add setRequestInterception

### DIFF
--- a/src/store/lookup.ts
+++ b/src/store/lookup.ts
@@ -160,6 +160,7 @@ async function lookup(browser: Browser, store: Store) {
 			? await browser.createIncognitoBrowserContext()
 			: browser.defaultBrowserContext();
 		const page = await context.newPage();
+		await page.setRequestInterception(true);
 
 		page.setDefaultNavigationTimeout(config.page.timeout);
 		await page.setUserAgent(getRandomUserAgent());


### PR DESCRIPTION
### Description

fixes #1311
Fixes #826

stops puppeteer exiting with exitcode 1

please head over to #1311 to see the detailed description

### Testing

couldn't run streetmerchant 24/7 without  `await page.setRequestInterception(true);` 

### New dependencies

no new dependencies
