### PR TITLE
refactor: change `.env` to be `dotenv`

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -27,7 +27,7 @@ assignees: jef
 ## Environment
 
 **OS:**
-**.env file:**
+**dotenv file:**
 
 ```dotenv
 

--- a/.gitignore
+++ b/.gitignore
@@ -4,9 +4,8 @@
 build/
 node_modules/
 
-.env*
-.*env
-!.env-example
+.env
+dotenv
 success-*.png
 
 *.wav

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -19,8 +19,8 @@ You do not need any computer skills, smarts, or anything of that nature. You are
     - To checkout a particular reference, use `git checkout <ref name>` after cloning.
 - Navigate to this project by entering `cd streetmerchant`.
 - Run `npm install`.
-- Make a copy of `.env-example` and name it `.env`.
-- Edit the `.env` file to your liking using a text editor (like [vscode](https://code.visualstudio.com/)).
+- Make a copy of `dotenv-example` and name it `dotenv`.
+- Edit the `dotenv` file to your liking using a text editor (like [vscode](https://code.visualstudio.com/)).
 - Run `npm run start` to start.
 
 At any point you want the program to stop, use ++ctrl+c++.
@@ -40,22 +40,22 @@ Available via GitHub Container Registry.
 ```sh
 # to run docker nightly
 docker run --cap-add=SYS_ADMIN \
-  -it --rm --env-file ./.env \
+  -it --rm --env-file ./dotenv \
   ghcr.io/jef/streetmerchant:nightly
 
 # to test notifications
 docker run --cap-add=SYS_ADMIN \
-  -it --rm --env-file ./.env \
+  -it --rm --env-file ./dotenv \
   ghcr.io/jef/streetmerchant:nightly test:notification:production
 ```
 
 ## Customization
 
-To customize streetmerchant, make a copy of `.env-example` as `.env` and make any changes to your liking. View [Reference](reference/application.md) for more information on variables and their usage.
+To customize streetmerchant, make a copy of `dotenv-example` as `dotenv` and make any changes to your liking. View [Reference](reference/application.md) for more information on variables and their usage.
 
 ???+ tip
     All environment variables are optional.
 
 ## For developers
 
-The command `npm run start:dev` can be used instead of `npm run start` to automatically restart the project when filesystem changes are detected in the `src/` folder or `.env` file.
+The command `npm run start:dev` can be used instead of `npm run start` to automatically restart the project when filesystem changes are detected in the `src/` folder or `dotenv` file.

--- a/docs/help/troubleshoot.md
+++ b/docs/help/troubleshoot.md
@@ -18,7 +18,7 @@ As a last case scenario, use `PUPPETEER_EXECUTABLE_PATH`. This will use your com
 
 For example:
 
-`.env`:
+`dotenv`:
 
 ```
 PUPPETEER_EXECUTABLE_PATH=/usr/bin/google-chrome-stable

--- a/dotenv-example
+++ b/dotenv-example
@@ -1,6 +1,7 @@
 # ** All configuration variables are optional **
-# Read https://github.com/jef/streetmerchant#customization for help on customizing this file
-#############################################################################################
+# Copy this file and name it as `dotenv` (without backticks)
+# Read https://jef.codes/streetmerchant/getting-started/#customization for help on customizing this file
+########################################################################################################
 
 ASCII_BANNER=""
 ASCII_COLOR=""

--- a/nodemon.json
+++ b/nodemon.json
@@ -3,6 +3,6 @@
   "ext": "ts",
   "watch": [
     "src/",
-    ".env"
+    "dotenv"
   ]
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,10 +1,14 @@
 import {banner} from './banner';
 
-import {config as config_} from 'dotenv';
+import dotenv from 'dotenv'
 import path from 'path';
 import {readFileSync} from 'fs';
 
-config_({path: path.resolve(__dirname, '../.env')});
+if (path.resolve(__dirname, '../dotenv').length !== 0) {
+	dotenv.config({path: path.resolve(__dirname, '../dotenv')});
+} else {
+	dotenv.config({path: path.resolve(__dirname, '../.env')});
+}
 
 console.info(
 	banner.render(
@@ -66,8 +70,8 @@ function envOrNumber(environment: string | undefined, number?: number): number {
 
 /**
  * Returns environment variable, given number, or default number,
- * while handling .env input errors for a Min/Max pair.
- * .env errors handled:
+ * while handling dotenv input errors for a Min/Max pair.
+ * dotenv errors handled:
  * - Min/Max swapped (Min larger than Max, Max smaller than Min)
  * - Min larger than default Max when no Max defined
  * - Max smaller than default Min when no Min defined
@@ -106,8 +110,8 @@ function envOrNumberMin(
 
 /**
  * Returns environment variable, given number, or default number,
- * while handling .env input errors for a Min/Max pair.
- * .env errors handled:
+ * while handling dotenv input errors for a Min/Max pair.
+ * dotenv errors handled:
  * - Min/Max swapped (Min larger than Max, Max smaller than Min)
  * - Min larger than default Max when no Max defined
  * - Max smaller than default Min when no Min defined

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
-import {startAPIServer, stopAPIServer} from './web';
+import {config} from './config'; // Needs to be loaded first
+import {startAPIServer, stopAPIServer} from './web'; // eslint-disable-line sort-imports
 import {Browser} from 'puppeteer';
-import {config} from './config';
 import {getSleepTime} from './util';
 import {logger} from './logger';
 import puppeteer from 'puppeteer-extra';

--- a/src/notification/mqtt.ts
+++ b/src/notification/mqtt.ts
@@ -65,7 +65,7 @@ function generateTopic(link: Link, store: Store, topic: string): string {
 
 /**
  * Basic protection against sending credentials in the clear over public networks.
- *	- Returns 'true' if password is supplied in .env but address/URL is not part of a private network
+ *	- Returns 'true' if password is supplied in dotenv but address/URL is not part of a private network
  *	- Private networks evaluated:	Class A, B, or C private IP's or linklocal URL ("*.local")
  *	- TLS could be implemented, however, the majority of MQTT services on the internet do not require user authentication.
  *	- If you find a 'cloud' MQTT broker requiring authentication for publishing alerts, consider using another MQTT service (for now).


### PR DESCRIPTION
<!-- Please use Conventional Commits to label your title -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/ -->
<!-- Example: feat: allow provided config object to extend other configs  -->

### Description

Refactored `.env` to be `dotenv` now. `.env` will still work until we release 4.0.0; then neither will work as it's a whole different system.

This is done because there are many cases where new users cannot find this file or have problems doing so. This should enable them to find and customize streetmerchant much easier.

### Testing

Local testing, seems to be working fine.
