### PR TITLE
Update filter.md

### DIFF
--- a/docs/reference/filter.md
+++ b/docs/reference/filter.md
@@ -69,7 +69,7 @@ Used with the `STORES` variable.
 | Cyberport | DE | `cyberport` |
 | EBGames | CA | `ebgames`|
 | eBuyer | UK | `ebuyer`|
-| El Corte Inglés | US | `elcorteingles`|
+| El Corte Inglés | ES | `elcorteingles`|
 | ePrice | IT | `eprice`|
 | Euronics | IT | `euronics`|
 | Euronics | DE | `euronics-de`|


### PR DESCRIPTION
El Corte Inglés mainly serves Spain, but also United Kingdom, Andorra, France and Portugal.

Change: US > ES