### PR TITLE
fix(store): update UK stores

### DIFF
--- a/src/store/model/amazon-uk.ts
+++ b/src/store/model/amazon-uk.ts
@@ -114,6 +114,16 @@ export const AmazonUk: Store = {
 		ttl: 300000,
 		urls: [
 			{
+				series: '3060ti',
+				url:
+					'https://www.amazon.co.uk/s?k=%2B%22RTX+3060+TI%22+-2060+-2070+-2080+-SUPER+-GTX&i=computers&rh=n%3A430500031%2Cp_n_availability%3A419162031&s=relevancerank&dc&qid=1601675291sb_noss'
+			},
+			{
+				series: '3070',
+				url:
+					'https://www.amazon.co.uk/s?k=%2B%22RTX+3070%22+-2060+-2070+-2080+-SUPER+-GTX+-3080&rh=n%3A430500031&ref=nb_sb_noss'
+			},
+			{
 				series: '3080',
 				url: [
 					'https://www.amazon.co.uk/s?k=%2B%22RTX+3080%22+-2080+-GTX&i=computers&rh=n%3A430500031%2Cp_n_availability%3A419162031&s=relevancerank&dc&qid=1601675291',
@@ -126,11 +136,6 @@ export const AmazonUk: Store = {
 					'https://www.amazon.co.uk/s?k=%2B%22RTX+3090%22+-3080+-GTX&i=computers&rh=n%3A430500031%2Cp_n_availability%3A419162031&s=relevancerank&dc&qid=1601675291',
 					'https://www.amazon.co.uk/s?k=%2B%22RTX+3090%22+-3080+-GTX&i=computers&rh=n%3A430500031%2Cp_n_availability%3A419162031&s=relevancerank&dc&qid=1601675594&page=2'
 				]
-			},
-			{
-				series: '3060ti',
-				url:
-					'https://www.amazon.co.uk/s?k=%2B%22RTX+3060+TI%22+-2060+-2070+-2080+-SUPER+-GTX&i=computers&rh=n%3A430500031%2Cp_n_availability%3A419162031&s=relevancerank&dc&qid=1601675291sb_noss'
 			}
 		]
 	},

--- a/src/store/model/amd-uk.ts
+++ b/src/store/model/amd-uk.ts
@@ -1,0 +1,96 @@
+import {Store} from './store';
+
+export const AmdUk: Store = {
+	currency: '£',
+	labels: {
+		inStock: [
+			{
+				container: '.btn-shopping-cart',
+				text: ['add to cart']
+			},
+			{
+				container: '.btn-radeon',
+				text: ['add to cart']
+			}
+		],
+		maxPrice: {
+			container: '.product-page-description h4',
+			euroFormat: false
+		},
+		outOfStock: [
+			{
+				container: '.product-out-of-stock',
+				text: ['out of stock']
+			},
+			{
+				container: '.btn-radeon',
+				text: ['sold out']
+			}
+		]
+	},
+	links: [
+		{
+			brand: 'test:brand',
+			model: 'test:model',
+			series: 'test:series',
+			url: 'https://www.amd.com/en/direct-buy/5450881400/gb'
+		},
+		{
+			brand: 'amd',
+			cartUrl:
+				'https://www.amd.com/en/direct-buy/5450881400/gb?add-to-cart=true',
+			model: '5950x',
+			series: 'ryzen5950',
+			url: 'https://www.amd.com/en/direct-buy/5450881400/gb'
+		},
+		{
+			brand: 'amd',
+			cartUrl:
+				'https://www.amd.com/en/direct-buy/5450881500/gb?add-to-cart=true',
+			model: '5900x',
+			series: 'ryzen5900',
+			url: 'https://www.amd.com/en/direct-buy/5450881500/gb'
+		},
+		{
+			brand: 'amd',
+			cartUrl:
+				'https://www.amd.com/en/direct-buy/5450881600/gb?add-to-cart=true',
+			model: '5800x',
+			series: 'ryzen5800',
+			url: 'https://www.amd.com/en/direct-buy/5450881600/gb'
+		},
+		{
+			brand: 'amd',
+			cartUrl:
+				'https://www.amd.com/en/direct-buy/5450881700/gb?add-to-cart=true',
+			model: '5600x',
+			series: 'ryzen5600',
+			url: 'https://www.amd.com/en/direct-buy/5450881700/gb'
+		},
+		{
+			brand: 'amd',
+			cartUrl:
+				'https://www.amd.com/en/direct-buy/5458374000/gb?add-to-cart=true',
+			model: 'amd reference',
+			series: 'rx6800',
+			url: 'https://www.amd.com/en/direct-buy/5458374000/gb'
+		},
+		{
+			brand: 'amd',
+			cartUrl:
+				'https://www.amd.com/en/direct-buy/5458374100/gb?add-to-cart=true',
+			model: 'amd reference',
+			series: 'rx6800xt',
+			url: 'https://www.amd.com/en/direct-buy/5458374100/gb'
+		},
+		{
+			brand: 'amd',
+			cartUrl:
+				'https://www.amd.com/en/direct-buy/5458374200/gb?add-to-cart=true',
+			model: 'amd reference',
+			series: 'rx6900xt',
+			url: 'https://www.amd.com/en/direct-buy/5458374200/gb'
+		}
+	],
+	name: 'amd-uk'
+};

--- a/src/store/model/argos.ts
+++ b/src/store/model/argos.ts
@@ -19,16 +19,28 @@ export const Argos: Store = {
 			url: 'https://www.argos.co.uk/product/5718469'
 		},
 		{
-			brand: 'asus',
+			brand: 'sony',
 			model: 'ps5 console',
 			series: 'sonyps5c',
-			url: 'https://www.argos.co.uk/product/6795199'
+			url: 'https://www.argos.co.uk/product/8349000'
 		},
 		{
 			brand: 'sony',
 			model: 'ps5 digital',
 			series: 'sonyps5de',
-			url: 'https://www.argos.co.uk/product/6795151'
+			url: 'https://www.argos.co.uk/product/8349024'
+		},
+		{
+			brand: 'microsoft',
+			model: 'xbox series x',
+			series: 'xboxsx',
+			url: 'https://www.argos.co.uk/product/8448262'
+		},
+		{
+			brand: 'microsoft',
+			model: 'xbox series s',
+			series: 'xboxss',
+			url: 'https://www.argos.co.uk/product/8448248'
 		}
 	],
 	name: 'argos'

--- a/src/store/model/aria.ts
+++ b/src/store/model/aria.ts
@@ -46,6 +46,11 @@ export const Aria: Store = {
 					'https://www.aria.co.uk/Products/Components/Graphics+Cards/NVIDIA+GeForce/GeForce+RTX+3060+Ti'
 			},
 			{
+				series: '3070',
+				url:
+					'https://www.aria.co.uk/Products/Components/Graphics+Cards/NVIDIA+GeForce/GeForce+RTX+3070'
+			},
+			{
 				series: '3080',
 				url:
 					'https://www.aria.co.uk/Products/Components/Graphics+Cards/NVIDIA+GeForce/GeForce+RTX+3080'
@@ -54,11 +59,6 @@ export const Aria: Store = {
 				series: '3090',
 				url:
 					'https://www.aria.co.uk/Products/Components/Graphics+Cards/NVIDIA+GeForce/GeForce+RTX+3090'
-			},
-			{
-				series: '3060ti',
-				url:
-					'https://www.aria.co.uk/Products/Components/Graphics+Cards/NVIDIA+GeForce/GeForce+RTX+3060+Ti'
 			}
 		]
 	},

--- a/src/store/model/awd.ts
+++ b/src/store/model/awd.ts
@@ -24,6 +24,34 @@ export const Awd: Store = {
 			series: 'test:series',
 			url:
 				'https://www.awd-it.co.uk/asus-nvidia-geforce-gt-710-silent-low-profile-2gb-gddr5-graphics-card-pci-e.html'
+		},
+		{
+			brand: 'amd',
+			model: '5600x',
+			series: 'ryzen5600',
+			url:
+				'https://www.awd-it.co.uk/amd-ryzen-5-5600x-cpu-six-core-3.7ghz-processor-socket-am4-retail.html'
+		},
+		{
+			brand: 'amd',
+			model: '5800x',
+			series: 'ryzen5800',
+			url:
+				'https://www.awd-it.co.uk/amd-ryzen-7-5800x-cpu-eight-core-3.8ghz-processor-socket-am4-retail.html'
+		},
+		{
+			brand: 'amd',
+			model: '5900x',
+			series: 'ryzen5900',
+			url:
+				'https://www.awd-it.co.uk/amd-ryzen-9-5900x-cpu-twelve-core-3.7ghz-processor-socket-am4-retail.html'
+		},
+		{
+			brand: 'amd',
+			model: '5950x',
+			series: 'ryzen5950',
+			url:
+				'https://www.awd-it.co.uk/amd-ryzen-9-5950x-sixteen-core-socket-am4-3.4ghz-processor.html'
 		}
 	],
 	linksBuilder: {

--- a/src/store/model/awd.ts
+++ b/src/store/model/awd.ts
@@ -9,12 +9,12 @@ export const Awd: Store = {
 			text: ['item(s)']
 		},
 		maxPrice: {
-			container: '.product-info .ty-price-num',
+			container: '.ty-price',
 			euroFormat: false // Note: Awd uses non-euroFromat as price seperator
 		},
 		outOfStock: {
-			container: '.vs-stock',
-			text: ['out of stock']
+			container: '.vs-stock.ty-float-left',
+			text: ['Out-of-stock']
 		}
 	},
 	links: [
@@ -24,72 +24,25 @@ export const Awd: Store = {
 			series: 'test:series',
 			url:
 				'https://www.awd-it.co.uk/asus-nvidia-geforce-gt-710-silent-low-profile-2gb-gddr5-graphics-card-pci-e.html'
-		},
-		{
-			brand: 'asus',
-			model: 'amd reference',
-			series: 'rx6800',
-			url:
-				'https://www.awd-it.co.uk/asus-tuf-gaming-radeon-rx-6800-oc-edition-16gb-gddr6-graphics-card.html'
-		},
-		{
-			brand: 'asus',
-			model: 'amd reference',
-			series: 'rx6800',
-			url:
-				'https://www.awd-it.co.uk/asus-rog-strix-radeon-rx-6800-oc-edition-16gb-gddr6-graphics-card.html'
-		},
-		{
-			brand: 'gigabyte',
-			model: 'amd reference',
-			series: 'rx6800',
-			url:
-				'https://www.awd-it.co.uk/gigabyte-radeon-rx-6800-gaming-oc-16gb-gddr6-graphics-card.html'
-		},
-		{
-			brand: 'gigabyte',
-			model: 'amd reference',
-			series: 'rx6800xt',
-			url:
-				'https://www.awd-it.co.uk/gigabyte-radeon-rx-6800-xt-gaming-oc-16gb-gddr6-graphics-card.html'
-		},
-		{
-			brand: 'amd',
-			model: '5600x',
-			series: 'ryzen5600',
-			url:
-				'https://www.awd-it.co.uk/amd-ryzen-5-5600x-cpu-six-core-3.7ghz-processor-socket-am4-retail.html'
-		},
-		{
-			brand: 'amd',
-			model: '5800x',
-			series: 'ryzen5800',
-			url:
-				'https://www.awd-it.co.uk/amd-ryzen-7-5800x-cpu-eight-core-3.8ghz-processor-socket-am4-retail.html'
-		},
-		{
-			brand: 'amd',
-			model: '5900x',
-			series: 'ryzen5900',
-			url:
-				'https://www.awd-it.co.uk/amd-ryzen-9-5900x-cpu-twelve-core-3.7ghz-processor-socket-am4-retail.html'
-		},
-		{
-			brand: 'amd',
-			model: '5950x',
-			series: 'ryzen5950',
-			url:
-				'https://www.awd-it.co.uk/amd-ryzen-9-5950x-sixteen-core-socket-am4-3.4ghz-processor.html'
 		}
 	],
 	linksBuilder: {
 		builder: getProductLinksBuilder({
 			productsSelector: '.grid-list .ty-grid-list__item',
 			sitePrefix: 'https://www.awd-it.co.uk',
-			titleSelector: '.title-price-wrapper',
-			urlSelector: 'a[href]'
+			titleSelector: '.product-title'
 		}),
 		urls: [
+			{
+				series: 'rx6800',
+				url:
+					'https://www.awd-it.co.uk/components/graphics-cards/ati/amd-radeon-6800-6800xt.html'
+			},
+			{
+				series: '3060ti',
+				url:
+					'https://www.awd-it.co.uk/components/graphics-cards/nvidia/nvidia-geforce-rtx-3060ti.html'
+			},
 			{
 				series: '3070',
 				url:
@@ -104,11 +57,6 @@ export const Awd: Store = {
 				series: '3090',
 				url:
 					'https://www.awd-it.co.uk/components/graphics-cards/nvidia/nvidia-geforce-rtx-3090.html'
-			},
-			{
-				series: '3060ti',
-				url:
-					'https://www.awd-it.co.uk/components/graphics-cards/nvidia/nvidia-geforce-rtx-3060ti.html'
 			}
 		]
 	},

--- a/src/store/model/box.ts
+++ b/src/store/model/box.ts
@@ -2,6 +2,7 @@ import {Store} from './store';
 import {getProductLinksBuilder} from './helpers/card';
 
 export const Box: Store = {
+	backoffStatusCodes: [403, 429, 503],
 	currency: '£',
 	labels: {
 		inStock: {
@@ -9,10 +10,11 @@ export const Box: Store = {
 			text: ['add to basket']
 		},
 		maxPrice: {
-			container: '.p-right-wrapper .pq-price',
+			container: '.p-price',
 			euroFormat: false // Note: Box uses non-euroFromat as price seperator
 		},
 		outOfStock: {
+			container: '#divBuyButton',
 			text: ['request stock alert', 'coming soon']
 		}
 	},
@@ -23,6 +25,41 @@ export const Box: Store = {
 			series: 'test:series',
 			url:
 				'https://www.box.co.uk/Gigabyte-GeForce-RTX-2080-Super-8GB-Wind_2724554.html'
+		},
+		{
+			brand: 'sony',
+			model: 'ps5 console',
+			series: 'sonyps5c',
+			url:
+				'https://www.box.co.uk/CFI-1015A-Sony-Playstation-5-Console_3199689.html'
+		},
+		{
+			brand: 'sony',
+			model: 'ps5 digital',
+			series: 'sonyps5de',
+			url:
+				'https://www.box.co.uk/CFI-1015B-Sony-PlayStation-5-Digital-Edition-Conso_3199692.html'
+		},
+		{
+			brand: 'microsoft',
+			model: 'xbox series x',
+			series: 'xboxsx',
+			url:
+				'https://www.box.co.uk/RRT-00007-Xbox-Series-X-Console_3201195.html'
+		},
+		{
+			brand: 'microsoft',
+			model: 'xbox series s',
+			series: 'xboxss',
+			url:
+				'https://www.box.co.uk/RRS-00007-Xbox-Series-S-Console_3201197.html'
+		},
+		{
+			brand: 'amd',
+			model: 'tuf oc',
+			series: 'rx6900xt',
+			url:
+				'https://www.box.co.uk/90YV0GE0-M0NM00-ASUS-Radeon-RX-X6900XT-16GB-OC-Gaming-Gr_3561243.html'
 		}
 	],
 	linksBuilder: {
@@ -47,10 +84,6 @@ export const Box: Store = {
 			{
 				series: '3090',
 				url: 'https://www.box.co.uk/rtx-3090-graphics-cards'
-			},
-			{
-				series: '3060ti',
-				url: 'https://www.box.co.uk/rtx-3060-ti-graphics-cards'
 			}
 		]
 	},

--- a/src/store/model/ccl.ts
+++ b/src/store/model/ccl.ts
@@ -64,6 +64,11 @@ export const Ccl: Store = {
 		}),
 		urls: [
 			{
+				series: '3060ti',
+				url:
+					'https://www.cclonline.com/category/430/PC-Components/Graphics-Cards/GeForce-RTX-3060-Ti-Graphics-Cards/'
+			},
+			{
 				series: '3070',
 				url:
 					'https://www.cclonline.com/category/430/PC-Components/Graphics-Cards/GeForce-RTX-3070-Graphics-Cards/'
@@ -89,9 +94,9 @@ export const Ccl: Store = {
 					'https://www.cclonline.com/category/430/PC-Components/Graphics-Cards/AMD-Radeon-RX-6800-XT-Graphics-Cards/'
 			},
 			{
-				series: '3060ti',
+				series: 'rx6900xt',
 				url:
-					'https://www.cclonline.com/category/430/PC-Components/Graphics-Cards/GeForce-RTX-3060-Ti-Graphics-Cards/'
+					'https://www.cclonline.com/category/430/PC-Components/Graphics-Cards/attributeslist/1268064/'
 			}
 		]
 	},

--- a/src/store/model/currys.ts
+++ b/src/store/model/currys.ts
@@ -53,7 +53,35 @@ export const Currys: Store = {
 			series: 'ryzen5950',
 			url:
 				'https://www.currys.co.uk/gbuk/computing-accessories/components-upgrades/processors/amd-ryzen-9-5950x-processor-10216688-pdt.html'
-		}
+		},
+		{
+			brand: 'sony',
+			model: 'ps5 console',
+			series: 'sonyps5c',
+			url:
+				'https://www.currys.co.uk/gbuk/gaming/console-gaming/consoles/sony-playstation-5-825-gb-10203370-pdt.html'
+		},
+		{
+			brand: 'sony',
+			model: 'ps5 digital',
+			series: 'sonyps5de',
+			url:
+				'https://www.currys.co.uk/gbuk/playstation-5-sony-1714-commercial.html'
+		},
+		{
+			brand: 'microsoft',
+			model: 'xbox series x',
+			series: 'xboxsx',
+			url:
+				'https://www.currys.co.uk/gbuk/gaming/console-gaming/consoles/microsoft-xbox-series-x-1-tb-10203371-pdt.html'
+		},
+		{
+			brand: 'microsoft',
+			model: 'xbox series s',
+			series: 'xboxss',
+			url:
+				'https://www.currys.co.uk/gbuk/gaming/console-gaming/consoles/microsoft-xbox-series-s-512-gb-ssd-10205195-pdt.html'
+		},
 	],
 	linksBuilder: {
 		builder: getProductLinksBuilder({

--- a/src/store/model/currys.ts
+++ b/src/store/model/currys.ts
@@ -81,7 +81,7 @@ export const Currys: Store = {
 			series: 'xboxss',
 			url:
 				'https://www.currys.co.uk/gbuk/gaming/console-gaming/consoles/microsoft-xbox-series-s-512-gb-ssd-10205195-pdt.html'
-		},
+		}
 	],
 	linksBuilder: {
 		builder: getProductLinksBuilder({

--- a/src/store/model/currys.ts
+++ b/src/store/model/currys.ts
@@ -82,11 +82,6 @@ export const Currys: Store = {
 				series: '3090',
 				url:
 					'https://www.currys.co.uk/gbuk/rtx-3090/components-upgrades/graphics-cards/324_3091_30343_xx_ba00013562-bv00313725/xx-criteria.html'
-			},
-			{
-				series: '3060ti',
-				url:
-					'https://www.currys.co.uk/gbuk/rtx-3060-ti/components-upgrades/graphics-cards/324_3091_30343_xx_ba00013562-bv00313952/xx-criteria.html'
 			}
 		]
 	},

--- a/src/store/model/ebuyer.ts
+++ b/src/store/model/ebuyer.ts
@@ -5,8 +5,8 @@ export const Ebuyer: Store = {
 	currency: '£',
 	labels: {
 		inStock: {
-			container: '.purchase-info',
-			text: ['add to basket', 'in stock', 'pre-order']
+			container: '.purchase-info__cta',
+			text: ['add to basket', 'pre-order']
 		},
 		maxPrice: {
 			container: '.purchase-info__price .price',
@@ -14,7 +14,7 @@ export const Ebuyer: Store = {
 		},
 		outOfStock: {
 			container: '.purchase-info',
-			text: ['coming soon', 'we are expecting this item on']
+			text: ['coming soon']
 		}
 	},
 	links: [
@@ -38,6 +38,20 @@ export const Ebuyer: Store = {
 			series: 'sonyps5de',
 			url:
 				'https://www.ebuyer.com/1125332-sony-playstation-5-digital-edition-cfi-1015b'
+		},
+		{
+			brand: 'microsoft',
+			model: 'xbox series x',
+			series: 'xboxsx',
+			url:
+				'https://www.ebuyer.com/1133948-xbox-series-x-console-rrt-00007'
+		},
+		{
+			brand: 'microsoft',
+			model: 'xbox series s',
+			series: 'xboxss',
+			url:
+				'https://www.ebuyer.com/1133947-xbox-series-s-all-digital-console-rrs-00007'
 		},
 		{
 			brand: 'amd',
@@ -87,6 +101,11 @@ export const Ebuyer: Store = {
 					'https://www.ebuyer.com/store/Components/cat/Graphics-Cards-AMD/subcat/AMD-RX-6800-XT'
 			},
 			{
+				series: 'rx6900xt',
+				url:
+					'https://www.ebuyer.com/store/Components/cat/Graphics-Cards-AMD/subcat/AMD-RX-6900-XT'
+			},
+			{
 				series: '3060ti',
 				url:
 					'https://www.ebuyer.com/store/Components/cat/Graphics-Cards-Nvidia/subcat/GeForce-RTX-3060-Ti'
@@ -105,11 +124,6 @@ export const Ebuyer: Store = {
 				series: '3090',
 				url:
 					'https://www.ebuyer.com/store/Components/cat/Graphics-Cards-Nvidia/subcat/GeForce-RTX-3090'
-			},
-			{
-				series: '3060ti',
-				url:
-					'https://www.ebuyer.com/store/Components/cat/Graphics-Cards-Nvidia/subcat/GeForce-RTX-3060-Ti'
 			}
 		]
 	},

--- a/src/store/model/game.ts
+++ b/src/store/model/game.ts
@@ -36,7 +36,21 @@ export const Game: Store = {
 			series: 'sonyps5de',
 			url:
 				'https://www.game.co.uk/en/playstation-5-digital-edition-2826341'
-		}
+		},
+		{
+			brand: 'microsoft',
+			model: 'xbox series x',
+			series: 'xboxsx',
+			url:
+				'https://www.game.co.uk/en/xbox-series-x-2831406'
+		},
+		{
+			brand: 'microsoft',
+			model: 'xbox series s',
+			series: 'xboxss',
+			url:
+				'https://www.game.co.uk/en/xbox-series-x-2831406'
+		},
 	],
 	name: 'game'
 };

--- a/src/store/model/game.ts
+++ b/src/store/model/game.ts
@@ -41,16 +41,14 @@ export const Game: Store = {
 			brand: 'microsoft',
 			model: 'xbox series x',
 			series: 'xboxsx',
-			url:
-				'https://www.game.co.uk/en/xbox-series-x-2831406'
+			url: 'https://www.game.co.uk/en/xbox-series-x-2831406'
 		},
 		{
 			brand: 'microsoft',
 			model: 'xbox series s',
 			series: 'xboxss',
-			url:
-				'https://www.game.co.uk/en/xbox-series-x-2831406'
-		},
+			url: 'https://www.game.co.uk/en/xbox-series-x-2831406'
+		}
 	],
 	name: 'game'
 };

--- a/src/store/model/helpers/card.ts
+++ b/src/store/model/helpers/card.ts
@@ -75,6 +75,8 @@ export function parseCard(name: string): Card | null {
 	name = name.replace(/\([^(]*\)/g, '');
 	name = name.replace(/, .+$/, '');
 	name = name.replace(/ with .+$/, '');
+	name = name.replace(/pci-express/gi, '');
+	name = name.replace(/ - .*$/g, '');
 
 	// Account for incorrect titles, e.g. MSIGeforce
 	name = name.replace(/geforce/i, '');
@@ -83,7 +85,7 @@ export function parseCard(name: string): Card | null {
 	name = name.replace(/\bgraphics card\b/gi, '');
 	name = name.replace(/\b(?<!founders) edition\b/gi, '');
 	name = name.replace(/\b(series )?bundle\b/gi, '');
-	name = name.replace(/\b\w+ fan\b/gi, '');
+	name = name.replace(/\bfan\b/gi, '');
 	name = name.replace(/\s{2,}/g, ' ').trim();
 
 	let model = name.split(' ');

--- a/src/store/model/index.ts
+++ b/src/store/model/index.ts
@@ -15,6 +15,7 @@ import {Amd} from './amd';
 import {AmdCa} from './amd-ca';
 import {AmdDe} from './amd-de';
 import {AmdIt} from './amd-it';
+import {AmdUk} from './amd-uk';
 import {AntOnline} from './antonline';
 import {Argos} from './argos';
 import {Aria} from './aria';
@@ -106,6 +107,7 @@ export const storeList = new Map([
 	[AmdCa.name, AmdCa],
 	[AmdDe.name, AmdDe],
 	[AmdIt.name, AmdIt],
+	[AmdUk.name, AmdUk],
 	[AntOnline.name, AntOnline],
 	[Argos.name, Argos],
 	[Aria.name, Aria],

--- a/src/store/model/overclockers.ts
+++ b/src/store/model/overclockers.ts
@@ -73,6 +73,11 @@ export const Overclockers: Store = {
 					'https://www.overclockers.co.uk/pc-components/graphics-cards/amd/radeon-rx-6800-xt-series'
 			},
 			{
+				series: 'rx6900xt',
+				url:
+					'https://www.overclockers.co.uk/pc-components/graphics-cards/amd/radeon-rx-6900-xt-series'
+			},
+			{
 				series: '3060ti',
 				url:
 					'https://www.overclockers.co.uk/pc-components/graphics-cards/nvidia/geforce-rtx-3060-ti'
@@ -94,11 +99,6 @@ export const Overclockers: Store = {
 				series: '3090',
 				url:
 					'https://www.overclockers.co.uk/pc-components/graphics-cards/nvidia/geforce-rtx-3090'
-			},
-			{
-				series: '3060ti',
-				url:
-					'https://www.overclockers.co.uk/pc-components/graphics-cards/nvidia/geforce-rtx-3060-ti'
 			}
 		]
 	},

--- a/src/store/model/scan.ts
+++ b/src/store/model/scan.ts
@@ -30,7 +30,7 @@ export const Scan: Store = {
 			model: 'test:model',
 			series: 'test:series',
 			url:
-				'https://www.scan.co.uk/products/nvidia-shield-tv-media-streamer-tegra-x1plus-processor-8gb-storage-2gb-ram-4k-hdr-ready-ai-upscaling'
+				'https://www.scan.co.uk/products/msi-geforce-rtx-2060-ventus-xs-oc-6gb-gddr6-vr-ready-graphics-card-1920-core-1710mhz-boost'
 		},
 		{
 			brand: 'sony',
@@ -43,48 +43,6 @@ export const Scan: Store = {
 			model: 'ps5 digital',
 			series: 'sonyps5de',
 			url: 'https://www.scan.co.uk/products/playstation-5-digital-edition'
-		},
-		{
-			brand: 'powercolor',
-			model: 'amd reference',
-			series: 'rx6800',
-			url:
-				'https://www.scan.co.uk/products/powercolor-radeon-rx-6800-16gb-gddr6-ray-tracing-graphics-card-7nm-rdna2-3840-streams'
-		},
-		{
-			brand: 'sapphire',
-			model: 'amd reference',
-			series: 'rx6800',
-			url:
-				'https://www.scan.co.uk/products/sapphire-radeon-rx-6800-16gb-gddr6-ray-tracing-graphics-card-7nm-rdna2-3840-streams-1815mhz-gpu'
-		},
-		{
-			brand: 'asus',
-			model: 'amd reference',
-			series: 'rx6800',
-			url:
-				'https://www.scan.co.uk/products/asus-radeon-rx-6800-16gb-gddr6-ray-tracing-graphics-card-7nm-rdna2-3840-streams-1815mhz-gpu-2105mhz'
-		},
-		{
-			brand: 'msi',
-			model: 'amd reference',
-			series: 'rx6800',
-			url:
-				'https://www.scan.co.uk/products/msi-radeon-rx-6800-16gb-gddr6-ray-tracing-graphics-card-7nm-rdna2-3840-streams-1700mhz-gpu'
-		},
-		{
-			brand: 'powercolor',
-			model: 'amd reference',
-			series: 'rx6800xt',
-			url:
-				'https://www.scan.co.uk/products/powercolor-radeon-rx-6800-xt-16gb-gddr6-ray-tracing-graphics-card-7nm-rdna2-4608-streams'
-		},
-		{
-			brand: 'sapphire',
-			model: 'amd reference',
-			series: 'rx6800xt',
-			url:
-				'https://www.scan.co.uk/products/sapphire-radeon-rx-6800-xt-16gb-gddr6-ray-tracing-graphics-card-7nm-rdna2-4608-streams-2015mhz'
 		},
 		{
 			brand: 'amd',
@@ -125,6 +83,21 @@ export const Scan: Store = {
 		ttl: 300000,
 		urls: [
 			{
+				series: 'rx6800',
+				url:
+					'https://www.scan.co.uk/shop/computer-hardware/gpu-amd/amd-radeon-rx-6800-pcie-40-graphics-cards'
+			},
+			{
+				series: 'rx6800xt',
+				url:
+					'https://www.scan.co.uk/shop/computer-hardware/gpu-amd/amd-radeon-rx-6800-xt-pcie-40-graphics-cards'
+			},
+			{
+				series: 'rx6900xt',
+				url:
+					'https://www.scan.co.uk/shop/computer-hardware/gpu-amd/amd-radeon-rx-6900-xt-pcie-40-graphics-cards'
+			},
+			{
 				series: '3060ti',
 				url:
 					'https://www.scan.co.uk/shop/computer-hardware/gpu-nvidia/geforce-rtx-3060-ti-graphics-cards'
@@ -143,11 +116,6 @@ export const Scan: Store = {
 				series: '3090',
 				url:
 					'https://www.scan.co.uk/shop/computer-hardware/gpu-nvidia/nvidia-geforce-rtx-3090-graphics-cards'
-			},
-			{
-				series: '3060ti',
-				url:
-					'https://www.scan.co.uk/shop/computer-hardware/gpu-nvidia/geforce-rtx-3060-ti-graphics-cards'
 			}
 		]
 	},


### PR DESCRIPTION
### Description

 Fixes #1348 

**New features:**

- **AMD-UK**: New store that scans for all Ryzen 5000 and RX 6000 series products.

**Bug fixes and improvements:**

- **Amazon-UK**: Add RTX 3070.
- **Argos**: Updated PS5 links. Add Xbox Series S/X.
- **Aria**: Add RTX 3070. Remove duplicate 3060ti link builder.
- **AWD-IT**: Updated container labels to more accurately parse info. Remove hard-coded links in favour of link builders. Add RX 6800/XT series. Remove duplicate RTX 3060Ti link builder.
- **Box**: Add backoffstatuscodes. Update price and outOfStock container labels. Add PS5 and Xbox Series S/X models. Add RX6900XT model.
- **CCL**: Add RX 6900XT.
- **Currys**: Remove duplicate RTX 3060ti link builder. Add PS5 and Xbox Series S/X consoles.
- **eBuyer**: Update labels. Add Xbox Series S/X consoles. Add RX 6900XT.
- **Game**: Add Xbox Series S/X consoles.
- **Overclockers**: Add RX 6900XT. Remove duplicate RTX 3060ti link builder.
- **Scan**: Update test link to a product that is in stock. Remove hard-coded links in favour of link builders for RX 6800/XT and RX 6900XT. Removed duplicate 3060ti link builder. Fixed a particular RTX 3070 card not correctly being parsed.

### Testing

Manual testing has been performed to verify the changes are robust.