### PR TITLE
feat(store): add Irish store variants

### DIFF
--- a/docs/reference/filter.md
+++ b/docs/reference/filter.md
@@ -48,6 +48,7 @@ Used with the `STORES` variable.
 | AMD | IT | `amd-it`|
 | AntOnline | US | `antonline`|
 | Argos | UK | `argos`|
+| Argos | IE | `argos-ie`|
 | Aria PC | UK | `aria`|
 | ARLT | DE | `arlt`|
 | ASUS | US | `asus` |
@@ -80,6 +81,8 @@ Used with the `STORES` variable.
 | Game | UK | `game`|
 | Gamestop | US | `gamestop`|
 | Gamestop | DE | `gamestop-de`|
+| Gamestop | IE | `gamestop-ie`|
+| Harvey Normans | IE | | `harveynorman-ie` |
 | Kabum | BR | `kabum`|
 | Mediamarkt | DE | `mediamarkt`|
 | Medimax | DE | `medimax`|
@@ -104,8 +107,10 @@ Used with the `STORES` variable.
 | Saturn | DE | `saturn`|
 | Scan | UK | `scan`|
 | Smyths Toys | UK | `smythstoys`|
+| Smyths Toys | IE | `smythstoys-ie`|
 | Spielegrotte | DE | `spielegrotte`|
 | Target | US | `target`|
+| Tesco | IE | `tesco-ie`|
 | Toys R Us | US | `toysrus` |
 | Unieuro | IT | `unieuro`|
 | Very | UK | `very`|

--- a/src/store/model/argos-ie.ts
+++ b/src/store/model/argos-ie.ts
@@ -1,0 +1,35 @@
+import {Store} from './store';
+
+export const ArgosIE: Store = {
+	currency: '€',
+	labels: {
+		inStock: {
+			container: '.btnbuyreserve',
+			text: ['buy or reserve']
+		},
+		maxPrice: {
+			container: '.price'
+		},
+		outOfStock: {
+			container: '#subCopy',
+			text: ["We're working hard to get more stock."]
+		}
+	},
+	links: [
+		{
+			brand: 'microsoft',
+			model: 'xbox series x',
+			series: 'xboxsx',
+			url:
+				'http://www.argos.ie/static/Product/partNumber/8448262/Trail/searchtext%3EXBOX+SERIES+X.htm'
+		},
+		{
+			brand: 'sony',
+			model: 'ps5 digital',
+			series: 'sonyps5de',
+			url:
+				'http://www.argos.ie/static/Product/partNumber/8349000/Trail/searchtext%3EPS5+CONSOLE.htm'
+		}
+	],
+	name: 'argos-ie'
+};

--- a/src/store/model/gamestop-ie.ts
+++ b/src/store/model/gamestop-ie.ts
@@ -1,0 +1,31 @@
+import {Store} from './store';
+
+export const GamestopIE: Store = {
+	currency: '€',
+	labels: {
+		inStock: {
+			container: '#btnAddToCart',
+			text: ['add to cart!']
+		},
+		maxPrice: {
+			container: 'span.pricetext'
+		}
+	},
+	links: [
+		{
+			brand: 'microsoft',
+			model: 'xbox series x',
+			series: 'xboxsx',
+			url:
+				'https://www.gamestop.ie/Xbox%20Series/Games/73034/xbox-series-x-console'
+		},
+		{
+			brand: 'sony',
+			model: 'ps5 digital',
+			series: 'sonyps5de',
+			url:
+				'https://www.gamestop.ie/PlayStation%205/Games/72504/playstation-5-console'
+		}
+	],
+	name: 'gamestop-ie'
+};

--- a/src/store/model/harveynorman-ie.ts
+++ b/src/store/model/harveynorman-ie.ts
@@ -1,0 +1,30 @@
+import {Store} from './store';
+
+export const HarveyNormanIE: Store = {
+	currency: '€',
+	labels: {
+		inStock: {
+			container: 'input.btn-action',
+			text: ['add to cart']
+		},
+		maxPrice: {
+			container: '.price',
+			euroFormat: false
+		},
+		outOfStock: {
+			container: '.product-highlight-text',
+			text: ['SOLD OUT! WATCH THIS SPACE FOR MORE INFORMATION']
+		}
+	},
+	links: [
+		{
+			brand: 'microsoft',
+			model: 'xbox series x',
+			series: 'xboxsx',
+			url:
+				'https://www.harveynorman.ie/gaming/xbox-series/microsoft-xbox-series-x-console-1tb.html'
+		}
+	],
+	name: 'harveynorman-ie',
+	waitUntil: 'domcontentloaded'
+};

--- a/src/store/model/index.ts
+++ b/src/store/model/index.ts
@@ -17,6 +17,7 @@ import {AmdDe} from './amd-de';
 import {AmdIt} from './amd-it';
 import {AntOnline} from './antonline';
 import {Argos} from './argos';
+import {ArgosIE} from './argos-ie';
 import {Aria} from './aria';
 import {Arlt} from './arlt';
 import {Asus} from './asus';
@@ -50,6 +51,8 @@ import {Galaxus} from './galaxus';
 import {Game} from './game';
 import {Gamestop} from './gamestop';
 import {GamestopDE} from './gamestop-de';
+import {GamestopIE} from './gamestop-ie';
+import {HarveyNormanIE} from './harveynorman-ie';
 import {Kabum} from './kabum';
 import {Mediamarkt} from './mediamarkt';
 import {Medimax} from './medimax';
@@ -74,9 +77,11 @@ import {ProshopDK} from './proshop-dk';
 import {Saturn} from './saturn';
 import {Scan} from './scan';
 import {SmythsToys} from './smythstoys';
+import {SmythsToysIE} from './smythstoys-ie';
 import {Spielegrotte} from './spielegrotte';
 import {Store} from './store';
 import {Target} from './target';
+import {TescoIE} from './tesco-ie';
 import {TopAchat} from './topachat';
 import {ToysRUs} from './toysrus';
 import {Unieuro} from './unieuro';
@@ -108,6 +113,7 @@ export const storeList = new Map([
 	[AmdIt.name, AmdIt],
 	[AntOnline.name, AntOnline],
 	[Argos.name, Argos],
+	[ArgosIE.name, Argos],
 	[Aria.name, Aria],
 	[Arlt.name, Arlt],
 	[Asus.name, Asus],
@@ -141,6 +147,8 @@ export const storeList = new Map([
 	[Game.name, Game],
 	[Gamestop.name, Gamestop],
 	[GamestopDE.name, GamestopDE],
+	[GamestopIE.name, GamestopIE],
+	[HarveyNormanIE.name, HarveyNormanIE],
 	[Kabum.name, Kabum],
 	[Mediamarkt.name, Mediamarkt],
 	[Medimax.name, Medimax],
@@ -164,9 +172,11 @@ export const storeList = new Map([
 	[ProshopDK.name, ProshopDK],
 	[Saturn.name, Saturn],
 	[Scan.name, Scan],
+	[SmythsToysIE.name, SmythsToysIE],
 	[SmythsToys.name, SmythsToys],
 	[Spielegrotte.name, Spielegrotte],
 	[Target.name, Target],
+	[TescoIE.name, TescoIE],
 	[TopAchat.name, TopAchat],
 	[ToysRUs.name, ToysRUs],
 	[Unieuro.name, Unieuro],

--- a/src/store/model/smythstoys-ie.ts
+++ b/src/store/model/smythstoys-ie.ts
@@ -1,0 +1,38 @@
+import {Store} from './store';
+
+export const SmythsToysIE: Store = {
+	currency: '€',
+	disableAdBlocker: true,
+	labels: {
+		inStock: {
+			container: '#addToCartButton',
+			text: ['add to basket']
+		},
+		maxPrice: {
+			container: '.price_tag',
+			euroFormat: false
+		},
+		outOfStock: {
+			container: '.instoreMessage',
+			text: ['out of stock']
+		}
+	},
+	links: [
+		{
+			brand: 'microsoft',
+			model: 'xbox series x',
+			series: 'xboxsx',
+			url:
+				'https://www.smythstoys.com/ie/en-ie/video-games-and-tablets/xbox-gaming/xbox-series-x-%7c-s/xbox-series-x-%7c-s-consoles/xbox-series-x-1tb-console/p/192012'
+		},
+		{
+			brand: 'sony',
+			model: 'ps5 console',
+			series: 'sonyps5c',
+			url:
+				'https://www.smythstoys.com/ie/en-ie/video-games-and-tablets/playstation-5/playstation-5-consoles/playstation-5-console/p/191259'
+		}
+	],
+	name: 'smythstoys-ie',
+	waitUntil: 'domcontentloaded'
+};

--- a/src/store/model/tesco-ie.ts
+++ b/src/store/model/tesco-ie.ts
@@ -1,0 +1,34 @@
+import {Store} from './store';
+
+export const TescoIE: Store = {
+	currency: '€',
+	labels: {
+		inStock: {
+			container: 'input.submit:nth-child(5)',
+			text: ['add']
+		},
+		maxPrice: {
+			container: '.linePriceAbbr'
+		},
+		outOfStock: {
+			container: '.noStockTxtCentered > strong:nth-child(1)',
+			text: ['Sorry, this product is currently not available']
+		}
+	},
+	links: [
+		{
+			brand: 'microsoft',
+			model: 'xbox series x',
+			series: 'xboxsx',
+			url:
+				'https://secure.tesco.ie/groceries/Product/Details/?id=307835209'
+		},
+		{
+			brand: 'sony',
+			model: 'ps5 digital',
+			series: 'sonyps5de',
+			url: 'https://www.tesco.ie/groceries/product/details/?id=307756010'
+		}
+	],
+	name: 'tesco-ie'
+};


### PR DESCRIPTION
### Description

Added the following Irish variants of stores to this bot:

- [Gamestop](https://gamestop.ie)
- [Argos](https://argos.ie)
- [Harvey Norman](https://harveynorman.ie)
- [Smyths](https://smyths.ie)
- [Tesco](https://tesco.ie)

### Testing

Tested locally against the various new stores that were added in this PR.

### New dependencies

N/A