### PR TITLE
feat(proxy): fallback to a global proxy list

### DIFF
--- a/docs/reference/application.md
+++ b/docs/reference/application.md
@@ -22,7 +22,7 @@
 | `WEB_PORT` | Starts a webserver to be able to control the bot while it is running. Setting this value starts this service. |
 
 ???+ info
-    You can also have a list of proxies that are rotated while searching stores. Proxies can be read from a file named `STORENAME.proxies` in the format of `socks5://username:password@ip`; one per line. In this case, there is no need to use the `PROXY_*` environments.
+    There is more information on proxy settings in the [Proxy documentation](proxy.md).
 
 ???+ tip
     - You can also have a list of proxies that are rotated while searching stores. Proxies can be read from a file named `STORENAME.proxies` in the format of `socks5://username:password@ip`; one per line.

--- a/docs/reference/proxy.md
+++ b/docs/reference/proxy.md
@@ -1,0 +1,20 @@
+# Proxy
+
+## Filename
+
+Proxy configuration can be set either per store in a file called `storename.proxies` or globally in `global.proxies` in the streetmerchant root directory.
+
+If both exist, the store specific file will take precedence.
+
+## Format
+
+The format is one proxy per line with the following structure:
+`protocol://[user:password@]ip[:port]`
+
+Supported protocols are `http` and `socks5`.
+
+Valid examples include:
+- `socks5://1.2.3.4:3180`
+- `socks5://abcd:efgh@1.2.3.4:5678`
+- `http://1.2.3.4:80`
+- `http://abcd:efgh@1.2.3.4:8080`

--- a/src/config.ts
+++ b/src/config.ts
@@ -147,6 +147,14 @@ function envOrNumberMax(
 	return number ?? 0;
 }
 
+function loadProxyList(filename: string) {
+	return readFileSync(`${filename}.proxies`)
+		.toString()
+		.trim()
+		.split('\n')
+		.map((x) => x.trim());
+}
+
 const browser = {
 	isHeadless: envOrBoolean(process.env.HEADLESS),
 	isIncognito: envOrBoolean(process.env.INCOGNITO, false),
@@ -384,12 +392,14 @@ const store = {
 
 		let proxyList;
 		try {
-			proxyList = readFileSync(`${name}.proxies`)
-				.toString()
-				.trim()
-				.split('\n')
-				.map((x) => x.trim());
+			proxyList = loadProxyList(name);
 		} catch {}
+
+		if (!proxyList) {
+			try {
+				proxyList = loadProxyList('global');
+			} catch {}
+		}
 
 		return {
 			maxPageSleep: envOrNumberMax(


### PR DESCRIPTION
### Description

This allows to have one main proxy list that all stores can load from (some users have asked for this feature)

### Testing

<!-- Please describe the tests that you ran to verify your changes. -->
<!-- Provide instructions so we can reproduce. -->
<!-- Please also list any relevant details for your test configuration -->

### New dependencies

<!-- List any dependencies that are required for this change. -->
<!-- Otherwise, delete section. -->
