### PR TITLE
fix(lookup): check out of stock before price

### DIFF
--- a/src/store/lookup.ts
+++ b/src/store/lookup.ts
@@ -347,6 +347,15 @@ async function lookupCardInStock(store: Store, page: Page, link: Link) {
 		}
 	}
 
+	if (store.labels.outOfStock) {
+		if (
+			await pageIncludesLabels(page, store.labels.outOfStock, baseOptions)
+		) {
+			logger.info(Print.outOfStock(link, store, true));
+			return false;
+		}
+	}
+
 	if (store.labels.maxPrice) {
 		const maxPrice = config.store.maxPrice.series[link.series];
 
@@ -366,15 +375,6 @@ async function lookupCardInStock(store: Store, page: Page, link: Link) {
 	// ) {
 	// 	return store.realTimeInventoryLookup(link.itemNumber);
 	// }
-
-	if (store.labels.outOfStock) {
-		if (
-			await pageIncludesLabels(page, store.labels.outOfStock, baseOptions)
-		) {
-			logger.info(Print.outOfStock(link, store, true));
-			return false;
-		}
-	}
 
 	if (store.labels.inStock) {
 		const options = {


### PR DESCRIPTION
Checking for Out of Stock before checking for max Price

### Description

Fixes #1421
<!-- Please also include relevant motivation and context. -->

### Testing

Tested it briefly on Ubuntu Desktop 20.04 and it worked

### New dependencies

none
