### PR TITLE
feat(lookup): handle Cloudflare DDoS protection

### DIFF
--- a/src/logger.ts
+++ b/src/logger.ts
@@ -95,6 +95,18 @@ export const Print = {
 
 		return `✖ ${buildProductString(link, store)} :: CAPTCHA`;
 	},
+	cloudflare(link: Link, store: Store, color?: boolean): string {
+		if (color) {
+			return (
+				'✖ ' +
+				buildProductString(link, store, true) +
+				' :: ' +
+				chalk.yellow('CLOUDFLARE, WAITING')
+			);
+		}
+
+		return `✖ ${buildProductString(link, store)} :: CLOUDFLARE, WAITING`;
+	},
 	inStock(link: Link, store: Store, color?: boolean, sms?: boolean): string {
 		const productString = `${buildProductString(link, store)} :: IN STOCK`;
 

--- a/src/store/lookup.ts
+++ b/src/store/lookup.ts
@@ -348,7 +348,8 @@ async function handleResponse(
 					store,
 					page,
 					link,
-					response);
+					response
+				);
 			} else {
 				logger.warn(Print.badStatusCode(link, store, statusCode, true));
 			}


### PR DESCRIPTION
### Description

Resolves #1297 

- Move response handling to a function that can be called recursively
- Check 503 responses for Cloudflare's "attribution" div + link text
- If we hit a Cloudflare page, do page.waitForNavigation and then call response handling again (recursively)

### Testing

Set store = "zotac"
Set brand & model = ""
Set series = "3070, 3080, 3090"
Run and observe output

Prior result: Frequent 503 errors due to Cloudflare protection

New result: Periodic "CLOUDFLARE, WAITING" message followed shortly by success (typically OUT OF STOCK)