### PR TITLE
docs(reference): add AWD-IT

### DIFF
--- a/docs/reference/filter.md
+++ b/docs/reference/filter.md
@@ -54,6 +54,7 @@ Used with the `STORES` variable.
 | ARLT | DE | `arlt`|
 | ASUS | US | `asus` |
 | ASUS | DE | `asus-de` |
+| AWD-IT | UK | `awd` |
 | Azerty | NL | `azerty`|
 | B&H | US | `bandh`|
 | Best Buy | US | `bestbuy`|


### PR DESCRIPTION
### Description

The store `AWD-IT` is missing from the documentation. 

This PR adds the missing store to the docs.