### PR TITLE
feat(store): Add german stores equippr and futurex (RTX 3080 only)

### DIFF
--- a/src/store/model/equippr.ts
+++ b/src/store/model/equippr.ts
@@ -1,0 +1,176 @@
+import {Store} from './store';
+
+export const Equippr: Store = {
+	currency: '€',
+	labels: {
+		inStock: {
+			container: '.delivery--information', 
+			text: [
+				'Sofort versandfertig, Lieferung innerhalb 1-3 Werktage',
+				'Jetzt bestellen. Lieferung innerhalb 3-5 Werktage',
+				'kurzfristig verfügbar'
+			]
+		},
+		maxPrice: {
+			container: '.price',
+			euroFormat: true
+		},
+		outOfStock: {
+			container: '.alert--content',
+			text: ['Bald verfügbar']
+		}
+	},
+	links: [
+		
+			{
+			brand: 'test:brand',
+			model: 'test:model',
+			series: 'test:sereis',
+			url:
+				'https://www.equippr.de/corsair-vengeance-lpx-32-gb-ddr4-3200-dimm-cl16-dual-kit-schwarz-cmk32gx4m2b3200c16-2011145.html'
+		},
+		
+		{
+			brand: 'asus',
+			model: 'strix',
+			series: '3080',
+			url:
+				'https://www.equippr.de/asus-geforce-rtx-3080-rog-strix-10-gb-gddr6x-retail-2059780.html'
+		},
+		{
+			brand: 'asus',
+			model: 'strix oc',
+			series: '3080',
+			url:
+				'https://www.equippr.de/asus-geforce-rtx-3080-rog-strix-oc-10-gb-gddr6x-retail-2059781.html'
+		},
+		{
+			brand: 'asus',
+			model: 'tuf',
+			series: '3080',
+			url:
+				'https://www.equippr.de/asus-geforce-rtx-3080-tuf-gaming-10-gb-gddr6x-retail-2059776.html'
+		},
+		{
+			brand: 'asus',
+			model: 'tuf oc',
+			series: '3080',
+			url:
+				'https://www.equippr.de/asus-geforce-rtx-3080-tuf-gaming-oc-10-gb-gddr6x-retail-2059777.html'
+		},
+	
+		{
+			brand: 'evga',
+			model: 'ftw3 ultra',
+			series: '3080',
+			url:
+				'https://www.equippr.de/evga-geforce-rtx-3080-ftw3-ultra-gaming-10-gb-gddr6x-retail-2061553.html'
+		},
+		{
+			brand: 'evga',
+			model: 'xc3',
+			series: '3080',
+			url:
+				'https://www.equippr.de/evga-geforce-rtx-3080-xc3-gaming-10-gb-gddr6x-retail-2061391.html'
+		},
+		{
+			brand: 'evga',
+			model: 'xc3 black',
+			series: '3080',
+			url:
+				'https://www.equippr.de/evga-geforce-rtx-3080-xc3-black-gaming-10-gb-gddr6x-retail-2061390.html'
+		},
+		{
+			brand: 'evga',
+			model: 'xc3 ultra',
+			series: '3080',
+			url:
+				'https://www.equippr.de/evga-geforce-rtx-3080-xc3-ultra-gaming-10-gb-gddr6x-retail-2061393.html'
+		},
+		{
+			brand: 'gainward',
+			model: 'phoenix',
+			series: '3080',
+			url:
+				'https://www.equippr.de/gainward-geforce-rtx-3080-phoenix-10-gb-gddr6x-retail-2061395.html'
+		},
+		{
+			brand: 'gainward',
+			model: 'phoenix gs',
+			series: '3080',
+			url:
+				'https://www.equippr.de/gainward-geforce-rtx-3080-phoenix-gs-10-gb-gddr6x-retail-2061394.html'
+		},
+		
+		{
+			brand: 'gigabyte',
+			model: 'gaming oc',
+			series: '3080',
+			url:
+				'https://www.equippr.de/gigabyte-geforce-rtx-3080-gaming-oc-10-gb-gddr6x-retail-2061386.html'
+		},
+		
+		{
+			brand: 'inno3d',
+			model: 'ichill x3',
+			series: '3080',
+			url:
+				'https://www.equippr.de/inno3d-geforce-rtx-3080-ichill-x3-10-gb-gddr6x-retail-2060455.html'
+		},
+		{
+			brand: 'inno3d',
+			model: 'ichill x4',
+			series: '3080',
+			url:
+				'https://www.equippr.de/inno3d-geforce-rtx-3080-ichill-x4-10-gb-gddr6x-retail-2060456.html'
+		},
+		
+		{
+			brand: 'msi',
+			model: 'gaming x trio',
+			series: '3080',
+			url:
+				'https://www.equippr.de/msi-geforce-rtx-3080-gaming-x-trio-10-gb-gddr6x-retail-2060387.html'
+		},
+		{brand: 'msi',
+			model: 'ventus 3x oc',
+			series: '3080',
+			url:
+				'https://www.equippr.de/msi-geforce-rtx-3080-ventus-3x-oc-10-gb-gddr6x-retail-2060386.html'
+			
+		},
+		{ brand: 'msi',
+			model: 'suprim x',
+			series: '3080',
+			url:
+				'https://www.equippr.de/msi-geforce-rtx-3080-suprim-x-10-gb-gddr6x-retail-2066166.html'
+		
+		
+		
+		},
+		
+		{
+			brand: 'zotac',
+			model: 'amp holo',
+			series: '3080',
+			url:
+				'https://www.equippr.de/zotac-geforce-rtx-3080-amp-holo-10-gb-gddr6x-retail-2061396.html'
+		},
+		
+		{
+			brand: 'zotac',
+			model: 'trinity',
+			series: '3080',
+			url:
+				'https://www.equippr.de/zotac-geforce-rtx-3080-trinity-10-gb-gddr6x-retail-2060389.html'
+		},
+		{
+			brand: 'zotac',
+			model: 'trinity oc',
+			series: '3080',
+			url:
+				'https://www.equippr.de/zotac-geforce-rtx-3080-trinity-oc-10-gb-gddr6x-retail-2061397.html'
+		}
+	],
+	name: 'equippr'
+};

--- a/src/store/model/equippr.ts
+++ b/src/store/model/equippr.ts
@@ -25,7 +25,7 @@ export const Equippr: Store = {
 			{
 			brand: 'test:brand',
 			model: 'test:model',
-			series: 'test:sereis',
+			series: 'test:series',
 			url:
 				'https://www.equippr.de/corsair-vengeance-lpx-32-gb-ddr4-3200-dimm-cl16-dual-kit-schwarz-cmk32gx4m2b3200c16-2011145.html'
 		},

--- a/src/store/model/futurex.ts
+++ b/src/store/model/futurex.ts
@@ -28,7 +28,7 @@ export const Futurex: Store = {
 		{
 			brand: 'test:brand',
 			model: 'test:model',
-			series: 'test:sereis',
+			series: 'test:series',
 			url:
 				'https://www.future-x.de/corsair-vengeance-lpx-ddr4-32-gb%3A-2-x-16-gb-dimm-288-pin-3200-mhz-pc4-25600-cl16-135-v-ungepuffert-nicht-ecc-schwarz-p-494897/'
 		},

--- a/src/store/model/futurex.ts
+++ b/src/store/model/futurex.ts
@@ -1,0 +1,88 @@
+import {Store} from './store';
+
+export const Futurex: Store = {
+	currency: '€',
+	labels: {
+		inStock: {
+			container: '.productPriceInner',
+			text: [
+				'Auf Lager'
+				
+			]
+		},
+		maxPrice: {
+			container:	'.price',
+			euroFormat: true
+		},
+		outOfStock: [
+			{
+				container: '.notavail',
+				text: ['Aktuell nicht verfügbar'
+					
+				]
+		
+			}
+		]
+	},
+	links: [
+		{
+			brand: 'test:brand',
+			model: 'test:model',
+			series: 'test:sereis',
+			url:
+				'https://www.future-x.de/corsair-vengeance-lpx-ddr4-32-gb%3A-2-x-16-gb-dimm-288-pin-3200-mhz-pc4-25600-cl16-135-v-ungepuffert-nicht-ecc-schwarz-p-494897/'
+		},
+		
+		 {
+			brand: 'asus',
+			model: 'tuf oc',
+			series: '3080',
+			url:
+				'https://www.future-x.de/asus-vga-10gb-rtx3080-tuf-gaming-oc-3xdp-2xhdmi-geforce-rtx-3080-grafikkarte-pci-express-10240-mb-displayport-eingang-p-8649614'
+		}, 
+		
+		{
+			brand: 'asus',
+			model: 'strix',
+			series: '3080',
+			url:
+				'https://www.future-x.de/asus-rog-strix-geforce-rtx-3080-10gb-grafikkarte-pci-express-10240-mb-displayport-eingang-p-8649611/'
+		},
+	
+				
+		{
+			brand: 'msi',
+			model: 'gaming x trio',
+			series: '3080',
+			url:
+				'https://www.future-x.de/msi-geforce-rtx-3080-gaming-x-tr-grafikkarte-10240-mb-p-8649610/'
+		},
+		
+		{brand: 'msi',
+			model: 'ventus 3x oc',
+			series: '3080',
+			url:
+				'https://www.future-x.de/msi-geforce-rtx-3080ventus-3x10g-oc-grafikkarte-10240-mb-p-8649609/'
+			
+		},
+				
+		{
+			brand: 'zotac',
+			model: 'amp holo',
+			series: '3080',
+			url:
+				'https://www.future-x.de/zotac-gaming-geforce-rtx-3080-amp-holo-memory-10gb-gddr6x-320-bit-p-8649625/'
+		},
+		
+		{
+			brand: 'zotac',
+			model: 'trinity',
+			series: '3080',
+			url:
+				'https://www.equippr.de/zotac-geforce-rtx-3080-trinity-10-gb-gddr6x-retail-2060389.html'
+		}
+		
+		
+	],
+	name: 'futurex'
+};

--- a/src/store/model/index.ts
+++ b/src/store/model/index.ts
@@ -46,9 +46,9 @@ import {EbGames} from './ebgames';
 import {Ebuyer} from './ebuyer';
 import {Elcorteingles} from './elcorteingles';
 import {Eprice} from './eprice';
+import {Equippr} from './equippr';
 import {Euronics} from './euronics';
 import {EuronicsDE} from './euronics-de';
-import {Equippr} from './equippr';
 import {Evga} from './evga';
 import {EvgaEu} from './evga-eu';
 import {Expert} from './expert';
@@ -82,7 +82,6 @@ import {PlayStation} from './playstation';
 import {Pny} from './pny';
 import {ProshopDE} from './proshop-de';
 import {ProshopDK} from './proshop-dk';
-import {Reichelt} from './reichelt';
 import {Saturn} from './saturn';
 import {Scan} from './scan';
 import {Scorptec} from './scorptec';
@@ -153,8 +152,8 @@ export const storeList = new Map([
 	[Ebuyer.name, Ebuyer],
 	[Elcorteingles.name, Elcorteingles],
 	[Eprice.name, Eprice],
-	[Euronics.name, Euronics],
 	[Equippr.name, Equippr],
+	[Euronics.name, Euronics],
 	[EuronicsDE.name, EuronicsDE],
 	[Evga.name, Evga],
 	[EvgaEu.name, EvgaEu],
@@ -189,7 +188,6 @@ export const storeList = new Map([
 	[Pny.name, Pny],
 	[ProshopDE.name, ProshopDE],
 	[ProshopDK.name, ProshopDK],
-	[Reichelt.name, Reichelt],
 	[Saturn.name, Saturn],
 	[Scan.name, Scan],
 	[Scorptec.name, Scorptec],

--- a/src/store/model/index.ts
+++ b/src/store/model/index.ts
@@ -48,9 +48,11 @@ import {Elcorteingles} from './elcorteingles';
 import {Eprice} from './eprice';
 import {Euronics} from './euronics';
 import {EuronicsDE} from './euronics-de';
+import {Equippr} from './equippr';
 import {Evga} from './evga';
 import {EvgaEu} from './evga-eu';
 import {Expert} from './expert';
+import {Futurex} from './futurex';
 import {Galaxus} from './galaxus';
 import {Game} from './game';
 import {Gamestop} from './gamestop';
@@ -80,6 +82,7 @@ import {PlayStation} from './playstation';
 import {Pny} from './pny';
 import {ProshopDE} from './proshop-de';
 import {ProshopDK} from './proshop-dk';
+import {Reichelt} from './reichelt';
 import {Saturn} from './saturn';
 import {Scan} from './scan';
 import {Scorptec} from './scorptec';
@@ -151,10 +154,12 @@ export const storeList = new Map([
 	[Elcorteingles.name, Elcorteingles],
 	[Eprice.name, Eprice],
 	[Euronics.name, Euronics],
+	[Equippr.name, Equippr],
 	[EuronicsDE.name, EuronicsDE],
 	[Evga.name, Evga],
 	[EvgaEu.name, EvgaEu],
 	[Expert.name, Expert],
+	[Futurex.name, Futurex],
 	[Galaxus.name, Galaxus],
 	[Game.name, Game],
 	[Gamestop.name, Gamestop],
@@ -184,6 +189,7 @@ export const storeList = new Map([
 	[Pny.name, Pny],
 	[ProshopDE.name, ProshopDE],
 	[ProshopDK.name, ProshopDK],
+	[Reichelt.name, Reichelt],
 	[Saturn.name, Saturn],
 	[Scan.name, Scan],
 	[Scorptec.name, Scorptec],


### PR DESCRIPTION
<!-- Please use Conventional Commits to label your title -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/ -->
<!-- Example: feat: allow provided config object to extend other configs  -->

### Description

Added german stores Equippr and Future-X.
Incl. RTX-3080 models to look up. Anything else one is looking for can be added.

(Not sure why it's acting like I thoroughly  replaced the whole index.ts - I just added the new stores)

