### PR TITLE
feat(store): add equippr & futurex for DE region

### DIFF
--- a/docs/reference/filter.md
+++ b/docs/reference/filter.md
@@ -92,6 +92,7 @@ Used with the `STORES` variable.
 | EVGA | US | `evga`|
 | EVGA | EU | `evga-eu`|
 | Expert | DE | `expert`|
+| Futurex | DE | `futurex`|
 | Galaxus | DE | `galaxus`|
 | Game | UK | `game`|
 | Gamestop | US | `gamestop`|

--- a/docs/reference/filter.md
+++ b/docs/reference/filter.md
@@ -88,6 +88,7 @@ Used with the `STORES` variable.
 | ePrice | IT | `eprice`|
 | Euronics | IT | `euronics`|
 | Euronics | DE | `euronics-de`|
+| Equippr | DE | `equippr`|
 | EVGA | US | `evga`|
 | EVGA | EU | `evga-eu`|
 | Expert | DE | `expert`|

--- a/src/store/model/equippr.ts
+++ b/src/store/model/equippr.ts
@@ -1,0 +1,94 @@
+import {Store} from './store';
+
+export const Equippr: Store = {
+	currency: '€',
+	labels: {
+		inStock: {
+			container: '.buybox--button .btn',
+			text: ['in den warenkorb']
+		},
+		maxPrice: {
+			container: '.product--price .price--default',
+			euroFormat: true
+		},
+		outOfStock: {
+			container: '.product--buybox .block',
+			text: ['bald verfügbar']
+		}
+	},
+	links: [
+		{
+			brand: 'test:brand',
+			model: 'test:model',
+			series: 'test:series',
+			url: 'https://www.equippr.de/amd-ryzen-5-2600x-6x-3-60-ghz-box-yd260xbcafbox-2000034.html'
+		},
+		{
+			brand: 'asus',
+			model: 'dual oc',
+			series: '3060ti',
+			url: 'https://www.equippr.de/asus-geforce-rtx-3060-ti-dual-8-gb-gddr6-retail-2066580.html'
+        },
+        {
+			brand: 'inno3d',
+			model: 'ichill x3',
+			series: '3060ti',
+			url: 'https://www.equippr.de/inno3d-geforce-rtx-3060-ti-ichill-x3-8-gb-gddr6-2066593.html'
+        },
+        {
+			brand: 'gigabyte',
+			model: 'aorus',
+			series: '3060ti',
+			url: 'https://www.equippr.de/gigabyte-geforce-rtx-3060-ti-aorus-8-gb-gddr6-retail-2066569.html'
+        },
+        {
+			brand: 'msi',
+			model: 'gaming x trio',
+			series: '3060ti',
+			url: 'https://www.equippr.de/msi-geforce-rtx-3060-ti-gaming-x-trio-8-gb-gddr6-retail-2066573.html'
+        },
+        {
+			brand: 'msi',
+			model: 'ventus 2x',
+			series: '3060ti',
+			url: 'https://www.equippr.de/msi-geforce-rtx-3060-ti-ventus-2x-oc-8-gb-gddr6-retail-2066574.html'
+        },
+        {
+			brand: 'zotac',
+			model: 'twin edge oc',
+			series: '3070',
+			url: 'https://www.equippr.de/zotac-geforce-rtx-3070-twin-edge-oc-8-gb-gddr6-retail-2064130.html'
+        },
+        {
+			brand: 'zotac',
+			model: 'twin edge',
+			series: '3070',
+			url: 'https://www.equippr.de/zotac-geforce-rtx-3070-twin-edge-8-gb-gddr6-retail-2060897.html'
+        },
+        {
+			brand: 'gigabyte',
+			model: 'eagle',
+			series: '3070',
+			url: 'https://www.equippr.de/gigabyte-geforce-rtx-3070-eagle-8-gb-gddr6-retail-2063884.html'
+        },
+        {
+			brand: 'gigabyte',
+			model: 'eagle oc',
+			series: '3070',
+			url: 'https://www.equippr.de/gigabyte-geforce-rtx-3070-eagle-oc-8-gb-gddr6-retail-2063882.html'
+        },
+        {
+			brand: 'evga',
+			model: 'xc3 ultra',
+			series: '3080',
+			url: 'https://www.equippr.de/evga-geforce-rtx-3080-xc3-ultra-gaming-10-gb-gddr6x-retail-2061393.html'
+        },
+        {
+			brand: 'evga',
+			model: 'xc3',
+			series: '3080',
+			url: 'https://www.equippr.de/evga-geforce-rtx-3080-xc3-gaming-10-gb-gddr6x-retail-2061391.html'
+        }
+	],
+	name: 'equippr'
+};

--- a/src/store/model/equippr.ts
+++ b/src/store/model/equippr.ts
@@ -21,74 +21,86 @@ export const Equippr: Store = {
 			brand: 'test:brand',
 			model: 'test:model',
 			series: 'test:series',
-			url: 'https://www.equippr.de/amd-ryzen-5-2600x-6x-3-60-ghz-box-yd260xbcafbox-2000034.html'
+			url:
+				'https://www.equippr.de/amd-ryzen-5-2600x-6x-3-60-ghz-box-yd260xbcafbox-2000034.html'
 		},
 		{
 			brand: 'asus',
 			model: 'dual oc',
 			series: '3060ti',
-			url: 'https://www.equippr.de/asus-geforce-rtx-3060-ti-dual-8-gb-gddr6-retail-2066580.html'
-        },
-        {
+			url:
+				'https://www.equippr.de/asus-geforce-rtx-3060-ti-dual-8-gb-gddr6-retail-2066580.html'
+		},
+		{
 			brand: 'inno3d',
 			model: 'ichill x3',
 			series: '3060ti',
-			url: 'https://www.equippr.de/inno3d-geforce-rtx-3060-ti-ichill-x3-8-gb-gddr6-2066593.html'
-        },
-        {
+			url:
+				'https://www.equippr.de/inno3d-geforce-rtx-3060-ti-ichill-x3-8-gb-gddr6-2066593.html'
+		},
+		{
 			brand: 'gigabyte',
 			model: 'aorus',
 			series: '3060ti',
-			url: 'https://www.equippr.de/gigabyte-geforce-rtx-3060-ti-aorus-8-gb-gddr6-retail-2066569.html'
-        },
-        {
+			url:
+				'https://www.equippr.de/gigabyte-geforce-rtx-3060-ti-aorus-8-gb-gddr6-retail-2066569.html'
+		},
+		{
 			brand: 'msi',
 			model: 'gaming x trio',
 			series: '3060ti',
-			url: 'https://www.equippr.de/msi-geforce-rtx-3060-ti-gaming-x-trio-8-gb-gddr6-retail-2066573.html'
-        },
-        {
+			url:
+				'https://www.equippr.de/msi-geforce-rtx-3060-ti-gaming-x-trio-8-gb-gddr6-retail-2066573.html'
+		},
+		{
 			brand: 'msi',
 			model: 'ventus 2x',
 			series: '3060ti',
-			url: 'https://www.equippr.de/msi-geforce-rtx-3060-ti-ventus-2x-oc-8-gb-gddr6-retail-2066574.html'
-        },
-        {
+			url:
+				'https://www.equippr.de/msi-geforce-rtx-3060-ti-ventus-2x-oc-8-gb-gddr6-retail-2066574.html'
+		},
+		{
 			brand: 'zotac',
 			model: 'twin edge oc',
 			series: '3070',
-			url: 'https://www.equippr.de/zotac-geforce-rtx-3070-twin-edge-oc-8-gb-gddr6-retail-2064130.html'
-        },
-        {
+			url:
+				'https://www.equippr.de/zotac-geforce-rtx-3070-twin-edge-oc-8-gb-gddr6-retail-2064130.html'
+		},
+		{
 			brand: 'zotac',
 			model: 'twin edge',
 			series: '3070',
-			url: 'https://www.equippr.de/zotac-geforce-rtx-3070-twin-edge-8-gb-gddr6-retail-2060897.html'
-        },
-        {
+			url:
+				'https://www.equippr.de/zotac-geforce-rtx-3070-twin-edge-8-gb-gddr6-retail-2060897.html'
+		},
+		{
 			brand: 'gigabyte',
 			model: 'eagle',
 			series: '3070',
-			url: 'https://www.equippr.de/gigabyte-geforce-rtx-3070-eagle-8-gb-gddr6-retail-2063884.html'
-        },
-        {
+			url:
+				'https://www.equippr.de/gigabyte-geforce-rtx-3070-eagle-8-gb-gddr6-retail-2063884.html'
+		},
+		{
 			brand: 'gigabyte',
 			model: 'eagle oc',
 			series: '3070',
-			url: 'https://www.equippr.de/gigabyte-geforce-rtx-3070-eagle-oc-8-gb-gddr6-retail-2063882.html'
-        },
-        {
+			url:
+				'https://www.equippr.de/gigabyte-geforce-rtx-3070-eagle-oc-8-gb-gddr6-retail-2063882.html'
+		},
+		{
 			brand: 'evga',
 			model: 'xc3 ultra',
 			series: '3080',
-			url: 'https://www.equippr.de/evga-geforce-rtx-3080-xc3-ultra-gaming-10-gb-gddr6x-retail-2061393.html'
-        },
-        {
+			url:
+				'https://www.equippr.de/evga-geforce-rtx-3080-xc3-ultra-gaming-10-gb-gddr6x-retail-2061393.html'
+		},
+		{
 			brand: 'evga',
 			model: 'xc3',
 			series: '3080',
-			url: 'https://www.equippr.de/evga-geforce-rtx-3080-xc3-gaming-10-gb-gddr6x-retail-2061391.html'
-        }
+			url:
+				'https://www.equippr.de/evga-geforce-rtx-3080-xc3-gaming-10-gb-gddr6x-retail-2061391.html'
+		}
 	],
 	name: 'equippr'
 };

--- a/src/store/model/equippr.ts
+++ b/src/store/model/equippr.ts
@@ -4,15 +4,15 @@ export const Equippr: Store = {
 	currency: '€',
 	labels: {
 		inStock: {
-			container: '.buybox--button .btn',
+			container: 'buybox--button-container',
 			text: ['in den warenkorb']
 		},
 		maxPrice: {
-			container: '.product--price .price--default',
+			container: '.product--price',
 			euroFormat: true
 		},
 		outOfStock: {
-			container: '.product--buybox .block',
+			container: '.product--buybox',
 			text: ['bald verfügbar']
 		}
 	},

--- a/src/store/model/futurex.ts
+++ b/src/store/model/futurex.ts
@@ -1,0 +1,73 @@
+import {Store} from './store';
+
+export const Futurex: Store = {
+	currency: '€',
+	labels: {
+		inStock: {
+			container: '.productPriceInner',
+			text: ['Auf Lager']
+		},
+		maxPrice: {
+			container: '.price',
+			euroFormat: true
+		},
+		outOfStock: [
+			{
+				container: '.notavail',
+				text: ['Aktuell nicht verfügbar']
+			}
+		]
+	},
+	links: [
+		{
+			brand: 'test:brand',
+			model: 'test:model',
+			series: 'test:series',
+			url:
+				'https://www.future-x.de/corsair-vengeance-lpx-ddr4-32-gb%3A-2-x-16-gb-dimm-288-pin-3200-mhz-pc4-25600-cl16-135-v-ungepuffert-nicht-ecc-schwarz-p-494897'
+		},
+		{
+			brand: 'asus',
+			model: 'tuf oc',
+			series: '3080',
+			url:
+				'https://www.future-x.de/asus-vga-10gb-rtx3080-tuf-gaming-oc-3xdp-2xhdmi-geforce-rtx-3080-grafikkarte-pci-express-10240-mb-displayport-eingang-p-8649614'
+		},
+		{
+			brand: 'asus',
+			model: 'strix',
+			series: '3080',
+			url:
+				'https://www.future-x.de/asus-rog-strix-geforce-rtx-3080-10gb-grafikkarte-pci-express-10240-mb-displayport-eingang-p-8649611'
+		},
+		{
+			brand: 'msi',
+			model: 'gaming x trio',
+			series: '3080',
+			url:
+				'https://www.future-x.de/msi-geforce-rtx-3080-gaming-x-tr-grafikkarte-10240-mb-p-8649610'
+		},
+		{
+			brand: 'msi',
+			model: 'ventus 3x oc',
+			series: '3080',
+			url:
+				'https://www.future-x.de/msi-geforce-rtx-3080ventus-3x10g-oc-grafikkarte-10240-mb-p-8649609'
+		},
+		{
+			brand: 'zotac',
+			model: 'amp holo',
+			series: '3080',
+			url:
+				'https://www.future-x.de/zotac-gaming-geforce-rtx-3080-amp-holo-memory-10gb-gddr6x-320-bit-p-8649625'
+		},
+		{
+			brand: 'zotac',
+			model: 'trinity',
+			series: '3080',
+			url:
+				'https://www.equippr.de/zotac-geforce-rtx-3080-trinity-10-gb-gddr6x-retail-2060389.html'
+		}
+	],
+	name: 'futurex'
+};

--- a/src/store/model/index.ts
+++ b/src/store/model/index.ts
@@ -53,6 +53,7 @@ import {EuronicsDE} from './euronics-de';
 import {Evga} from './evga';
 import {EvgaEu} from './evga-eu';
 import {Expert} from './expert';
+import {Futurex} from './futurex';
 import {Galaxus} from './galaxus';
 import {Game} from './game';
 import {Gamestop} from './gamestop';
@@ -162,6 +163,7 @@ export const storeList = new Map([
 	[Evga.name, Evga],
 	[EvgaEu.name, EvgaEu],
 	[Expert.name, Expert],
+	[Futurex.name, Futurex],
 	[Galaxus.name, Galaxus],
 	[Game.name, Game],
 	[Gamestop.name, Gamestop],

--- a/src/store/model/index.ts
+++ b/src/store/model/index.ts
@@ -49,6 +49,7 @@ import {Elcorteingles} from './elcorteingles';
 import {Eprice} from './eprice';
 import {Euronics} from './euronics';
 import {EuronicsDE} from './euronics-de';
+import {Equippr} from './equippr';
 import {Evga} from './evga';
 import {EvgaEu} from './evga-eu';
 import {Expert} from './expert';
@@ -157,6 +158,7 @@ export const storeList = new Map([
 	[Eprice.name, Eprice],
 	[Euronics.name, Euronics],
 	[EuronicsDE.name, EuronicsDE],
+	[Equippr.name, Equippr],
 	[Evga.name, Evga],
 	[EvgaEu.name, EvgaEu],
 	[Expert.name, Expert],

--- a/src/store/model/index.ts
+++ b/src/store/model/index.ts
@@ -47,9 +47,9 @@ import {EbGames} from './ebgames';
 import {Ebuyer} from './ebuyer';
 import {Elcorteingles} from './elcorteingles';
 import {Eprice} from './eprice';
+import {Equippr} from './equippr';
 import {Euronics} from './euronics';
 import {EuronicsDE} from './euronics-de';
-import {Equippr} from './equippr';
 import {Evga} from './evga';
 import {EvgaEu} from './evga-eu';
 import {Expert} from './expert';
@@ -156,9 +156,9 @@ export const storeList = new Map([
 	[Ebuyer.name, Ebuyer],
 	[Elcorteingles.name, Elcorteingles],
 	[Eprice.name, Eprice],
+	[Equippr.name, Equippr],
 	[Euronics.name, Euronics],
 	[EuronicsDE.name, EuronicsDE],
-	[Equippr.name, Equippr],
 	[Evga.name, Evga],
 	[EvgaEu.name, EvgaEu],
 	[Expert.name, Expert],


### PR DESCRIPTION
### Description

New store for German region - equippr.de and future-x.de with support for several Nvidia RTX 3060ti, 3070 and 3080.

### Testing

Edit the `dotenv` or `.env` to add the new store:

```
...
STORES=equippr,futurex
```

Sample Log: 

```
➜  ~ pm2 logs | grep equippr
0|Merchant | [9:43:33 AM] info :: ✖ [equippr] [msi (3060ti)] ventus 2x :: OUT OF STOCK
0|Merchant | [9:43:40 AM] info :: ✖ [equippr] [zotac (3070)] twin edge oc :: OUT OF STOCK
0|Merchant | [9:43:48 AM] info :: ✖ [equippr] [zotac (3070)] twin edge :: OUT OF STOCK
0|Merchant | [9:43:55 AM] info :: ✖ [equippr] [gigabyte (3070)] eagle :: OUT OF STOCK
0|Merchant | [9:44:00 AM] info :: ✖ [equippr] [gigabyte (3070)] eagle oc :: OUT OF STOCK
```

