### PR TITLE
fix: properly pass array entries as separate indices

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -387,7 +387,7 @@ const store = {
 		'xboxss',
 		'xboxsx'
 	]),
-	stores: envOrArray(process.env.STORES, ['amazon,bestbuy']).map((entry) => {
+	stores: envOrArray(process.env.STORES, ['amazon','bestbuy']).map((entry) => {
 		const [name, minPageSleep, maxPageSleep] = entry.match(/[^:]+/g) ?? [];
 
 		let proxyList;

--- a/src/config.ts
+++ b/src/config.ts
@@ -387,35 +387,38 @@ const store = {
 		'xboxss',
 		'xboxsx'
 	]),
-	stores: envOrArray(process.env.STORES, ['amazon','bestbuy']).map((entry) => {
-		const [name, minPageSleep, maxPageSleep] = entry.match(/[^:]+/g) ?? [];
+	stores: envOrArray(process.env.STORES, ['amazon', 'bestbuy']).map(
+		(entry) => {
+			const [name, minPageSleep, maxPageSleep] =
+				entry.match(/[^:]+/g) ?? [];
 
-		let proxyList;
-		try {
-			proxyList = loadProxyList(name);
-		} catch {}
-
-		if (!proxyList) {
+			let proxyList;
 			try {
-				proxyList = loadProxyList('global');
+				proxyList = loadProxyList(name);
 			} catch {}
-		}
 
-		return {
-			maxPageSleep: envOrNumberMax(
-				minPageSleep,
-				maxPageSleep,
-				browser.maxSleep
-			),
-			minPageSleep: envOrNumberMin(
-				minPageSleep,
-				maxPageSleep,
-				browser.minSleep
-			),
-			name: envOrString(name),
-			proxyList
-		};
-	})
+			if (!proxyList) {
+				try {
+					proxyList = loadProxyList('global');
+				} catch {}
+			}
+
+			return {
+				maxPageSleep: envOrNumberMax(
+					minPageSleep,
+					maxPageSleep,
+					browser.maxSleep
+				),
+				minPageSleep: envOrNumberMin(
+					minPageSleep,
+					maxPageSleep,
+					browser.minSleep
+				),
+				name: envOrString(name),
+				proxyList
+			};
+		}
+	)
 };
 
 export const defaultStoreData = {


### PR DESCRIPTION
<!-- Please use Conventional Commits to label your title -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/ -->
<!-- Example: feat: allow provided config object to extend other configs  -->

### Description
The array of stores by default contains two shops in one entry. To fix this, you must enter both shops as separate entries.
<!-- Fixes #(issue) -->
<!-- Please also include relevant motivation and context. -->

### Testing
## old
**[11:19:59 AM] warn :: No store named amazon,bestbuy, skipping.**
[11:19:59 AM] info :: ℹ selected stores: amazon,bestbuy
[11:19:59 AM] info :: ℹ selected series: 3060ti, 3070, 3080, 3090, rx6800, rx6800xt, rx6900xt, ryzen5600, ryzen5800, ryzen5900, ryzen5950, sonyps5c, sonyps5de, xboxss, xboxsx

## after fix
**[11:25:15 AM] info :: ℹ selected stores: amazon, bestbuy**
[11:25:15 AM] info :: ℹ selected series: 3060ti, 3070, 3080, 3090, rx6800, rx6800xt, rx6900xt, ryzen5600, ryzen5800, ryzen5900, ryzen5950, sonyps5c, sonyps5de, xboxss, xboxsx
[11:25:28 AM] info :: ✖ [amazon] [asus (3080)] strix :: OUT OF STOCK
[11:25:31 AM] info :: ✖ [amazon] [msi (3080)] gaming x trio :: OUT OF STOCK
