### PR TITLE
feat(lookup): Add protection against infinite recursion for Cloudflare…

### DIFF
--- a/src/logger.ts
+++ b/src/logger.ts
@@ -107,18 +107,6 @@ export const Print = {
 
 		return `✖ ${buildProductString(link, store)} :: CLOUDFLARE, WAITING`;
 	},
-	recursionLimit(link: Link, store: Store, color?: boolean): string {
-		if (color) {
-			return (
-				'✖ ' +
-				buildProductString(link, store, true) +
-				' :: ' +
-				chalk.yellow('CLOUDFLARE RETRY LIMIT REACHED, ABORT')
-			);
-		}
-
-		return `✖ ${buildProductString(link, store)} :: CLOUDFLARE RETRY LIMIT REACHED, ABORT`;
-	},
 	inStock(link: Link, store: Store, color?: boolean, sms?: boolean): string {
 		const productString = `${buildProductString(link, store)} :: IN STOCK`;
 
@@ -224,6 +212,21 @@ export const Print = {
 		}
 
 		return `✖ ${buildProductString(link, store)} :: RATE LIMIT EXCEEDED`;
+	},
+	recursionLimit(link: Link, store: Store, color?: boolean): string {
+		if (color) {
+			return (
+				'✖ ' +
+				buildProductString(link, store, true) +
+				' :: ' +
+				chalk.yellow('CLOUDFLARE RETRY LIMIT REACHED, ABORT')
+			);
+		}
+
+		return `✖ ${buildProductString(
+			link,
+			store
+		)} :: CLOUDFLARE RETRY LIMIT REACHED, ABORT`;
 	}
 };
 

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -107,6 +107,18 @@ export const Print = {
 
 		return `✖ ${buildProductString(link, store)} :: CLOUDFLARE, WAITING`;
 	},
+	recursionLimit(link: Link, store: Store, color?: boolean): string {
+		if (color) {
+			return (
+				'✖ ' +
+				buildProductString(link, store, true) +
+				' :: ' +
+				chalk.yellow('CLOUDFLARE RETRY LIMIT REACHED, ABORT')
+			);
+		}
+
+		return `✖ ${buildProductString(link, store)} :: CLOUDFLARE RETRY LIMIT REACHED, ABORT`;
+	},
 	inStock(link: Link, store: Store, color?: boolean, sms?: boolean): string {
 		const productString = `${buildProductString(link, store)} :: IN STOCK`;
 

--- a/src/store/lookup.ts
+++ b/src/store/lookup.ts
@@ -328,7 +328,8 @@ async function handleResponse(
 	store: Store,
 	page: Page,
 	link: Link,
-	response?: Response | null
+	response?: Response | null,
+	recursionDepth: number = 0
 ) {
 	if (!response) {
 		logger.debug(Print.noResponse(link, store, true));
@@ -341,16 +342,22 @@ async function handleResponse(
 			logger.warn(Print.rateLimit(link, store, true));
 		} else if (statusCode === 503) {
 			if (await checkIsCloudflare(store, page, link)) {
-				const response: Response | null = await page.waitForNavigation({
-					waitUntil: 'networkidle0'
-				});
-				statusCode = await handleResponse(
-					browser,
-					store,
-					page,
-					link,
-					response
-				);
+				if (recursionDepth > 4) {
+					logger.warn(Print.recursionLimit(link, store, true))
+				} else {
+					const response: Response | null = await page.waitForNavigation({
+						waitUntil: 'networkidle0'
+					});
+					recursionDepth++;
+					statusCode = await handleResponse(
+						browser,
+						store,
+						page,
+						link,
+						response,
+						recursionDepth
+					);
+				}
 			} else {
 				logger.warn(Print.badStatusCode(link, store, statusCode, true));
 			}

--- a/src/store/lookup.ts
+++ b/src/store/lookup.ts
@@ -329,7 +329,7 @@ async function handleResponse(
 	page: Page,
 	link: Link,
 	response?: Response | null,
-	recursionDepth: number = 0
+	recursionDepth = 0
 ) {
 	if (!response) {
 		logger.debug(Print.noResponse(link, store, true));
@@ -343,11 +343,13 @@ async function handleResponse(
 		} else if (statusCode === 503) {
 			if (await checkIsCloudflare(store, page, link)) {
 				if (recursionDepth > 4) {
-					logger.warn(Print.recursionLimit(link, store, true))
+					logger.warn(Print.recursionLimit(link, store, true));
 				} else {
-					const response: Response | null = await page.waitForNavigation({
-						waitUntil: 'networkidle0'
-					});
+					const response: Response | null = await page.waitForNavigation(
+						{
+							waitUntil: 'networkidle0'
+						}
+					);
 					recursionDepth++;
 					statusCode = await handleResponse(
 						browser,


### PR DESCRIPTION
… when it never progresses past its DDoS protection page

### Description

Fixes #1459 
Fixes #1490 

Sometimes (particularly with certain user-agents) Cloudflare will infinitely redirect you to another DDoS protection page; this can lead to infinite recursion. This change aborts after being forwarded 5 times.

### Testing

Merge, set STORE=zotac, then "npm start run" until seeing "CLOUDFLARE RECURSION LIMIT REACHED, ABORTING"

### New dependencies

None