### PR TITLE
fix(amazon-de-warehouse): update wrong maxPrice selector

### DIFF
--- a/src/store/model/amazon-de-warehouse.ts
+++ b/src/store/model/amazon-de-warehouse.ts
@@ -16,7 +16,7 @@ export const AmazonDeWarehouse: Store = {
 			text: ['In den Einkaufswagen']
 		},
 		maxPrice: {
-			container: 'a-size-large a-color-price olpOfferPrice a-text-bold',
+			container: '.olpOfferPrice',
 			euroFormat: true
 		},
 		outOfStock: [


### PR DESCRIPTION
### Description

Fixes #1500
maxPrice selector was not matching properly for warehouse listings.

### Testing

Create a link in amazon-de-warehouse.ts targeting a product that has warehouse listings
Set MAX_PRICE for the link's defined product to something less than the lowest warehouse listing
Run

### New dependencies

None
