### PR TITLE
chore(philips-hue): correct the log text

### DIFF
--- a/src/notification/philips-hue.ts
+++ b/src/notification/philips-hue.ts
@@ -44,12 +44,12 @@ const adjustLightsWithAPI = (hueBridge: Api) => {
 	if (lightIds) {
 		const arrayOfIDs = lightIds.split(',');
 		arrayOfIDs.forEach((light) => {
-			logger.debug('adjusting all hue lights');
+			logger.debug('Adjusting specified lights');
 			(hueBridge.lights.setLightState(
 				light,
 				lightState
 			) as Promise<any>).catch((error: Error) => {
-				logger.error('Failed to adjust all lights.');
+				logger.error('Failed to adjust specified lights.');
 				logger.error(error);
 				throw error;
 			});
@@ -60,12 +60,12 @@ const adjustLightsWithAPI = (hueBridge: Api) => {
 			.getAll()
 			.then((allLights: any[]) => {
 				allLights.forEach((light: any) => {
-					logger.debug('adjusting specified lights');
+					logger.debug('Adjusting all hue lights');
 					(hueBridge.lights.setLightState(
 						light,
 						lightState
 					) as Promise<any>).catch((error: Error) => {
-						logger.error('Failed to adjust specified lights.');
+						logger.error('Failed to adjust all lights.');
 						logger.error(error);
 						throw error;
 					});

--- a/src/notification/philips-hue.ts
+++ b/src/notification/philips-hue.ts
@@ -44,7 +44,7 @@ const adjustLightsWithAPI = (hueBridge: Api) => {
 	if (lightIds) {
 		const arrayOfIDs = lightIds.split(',');
 		arrayOfIDs.forEach((light) => {
-			logger.debug('Adjusting specified lights');
+			logger.debug('adjusting specified lights');
 			(hueBridge.lights.setLightState(
 				light,
 				lightState
@@ -60,7 +60,7 @@ const adjustLightsWithAPI = (hueBridge: Api) => {
 			.getAll()
 			.then((allLights: any[]) => {
 				allLights.forEach((light: any) => {
-					logger.debug('Adjusting all hue lights');
+					logger.debug('adjusting all hue lights');
 					(hueBridge.lights.setLightState(
 						light,
 						lightState


### PR DESCRIPTION
<!-- Please use Conventional Commits to label your title -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/ -->
<!-- Example: feat: allow provided config object to extend other configs  -->

### Description

Super minor change to the log output, it seems the text for these two blocks of the if/else were using the opposite verbiage

### Testing

Simply hooked up the Hue config and observed the log output locally
