### PR TITLE
feat(pushover): add screenshot to push notification if available

### DIFF
--- a/src/notification/pushover.ts
+++ b/src/notification/pushover.ts
@@ -20,7 +20,7 @@ export function sendPushoverNotification(link: Link, store: Store) {
 						message: link.cartUrl ? link.cartUrl : link.url,
 						priority: pushover.priority,
 						title: Print.inStock(link, store),
-						...(link.screenshot && {file: `./${link.screenshot}`}),
+						...(link.screenshot && {file: `./${link.screenshot}`})
 				  }
 				: {
 						expire: pushover.expire,
@@ -28,7 +28,7 @@ export function sendPushoverNotification(link: Link, store: Store) {
 						priority: pushover.priority,
 						retry: pushover.retry,
 						title: Print.inStock(link, store),
-						...(link.screenshot && {file: `./${link.screenshot}`}),
+						...(link.screenshot && {file: `./${link.screenshot}`})
 				  };
 
 		push.send(message, (error: Error) => {

--- a/src/notification/pushover.ts
+++ b/src/notification/pushover.ts
@@ -20,7 +20,7 @@ export function sendPushoverNotification(link: Link, store: Store) {
 						message: link.cartUrl ? link.cartUrl : link.url,
 						priority: pushover.priority,
 						title: Print.inStock(link, store),
-						...(link.screenshot && { file: `./${link.screenshot}` }),
+						...(link.screenshot && {file: `./${link.screenshot}`}),
 				  }
 				: {
 						expire: pushover.expire,
@@ -28,7 +28,7 @@ export function sendPushoverNotification(link: Link, store: Store) {
 						priority: pushover.priority,
 						retry: pushover.retry,
 						title: Print.inStock(link, store),
-						...(link.screenshot && { file: `./${link.screenshot}` }),
+						...(link.screenshot && {file: `./${link.screenshot}`}),
 				  };
 
 		push.send(message, (error: Error) => {

--- a/src/notification/pushover.ts
+++ b/src/notification/pushover.ts
@@ -19,14 +19,16 @@ export function sendPushoverNotification(link: Link, store: Store) {
 				? {
 						message: link.cartUrl ? link.cartUrl : link.url,
 						priority: pushover.priority,
-						title: Print.inStock(link, store)
+						title: Print.inStock(link, store),
+						...(link.screenshot && { file: `./${link.screenshot}` }),
 				  }
 				: {
 						expire: pushover.expire,
 						message: link.cartUrl ? link.cartUrl : link.url,
 						priority: pushover.priority,
 						retry: pushover.retry,
-						title: Print.inStock(link, store)
+						title: Print.inStock(link, store),
+						...(link.screenshot && { file: `./${link.screenshot}` }),
 				  };
 
 		push.send(message, (error: Error) => {


### PR DESCRIPTION
<!-- Please use Conventional Commits to label your title -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/ -->
<!-- Example: feat: allow provided config object to extend other configs  -->

### Description

<!-- Fixes #(issue) -->
<!-- Please also include relevant motivation and context. -->
Include screenshot image to pushover if it exists (similar to email notification), since pushover is capable of receiving image. On iOS, we can long tap or pull down to see an overview. 

Feel free to make any changes if required or close this if not.

### Testing

<!-- Please describe the tests that you ran to verify your changes. -->
<!-- Provide instructions so we can reproduce. -->
<!-- Please also list any relevant details for your test configuration -->
No test done, since I don't use the app (nor the package) and I don't know how to test it too. Please help to code review.