### PR TITLE
feat(store): add GPU and CPU support for Vuugo

### DIFF
--- a/docs/reference/filter.md
+++ b/docs/reference/filter.md
@@ -137,6 +137,7 @@ Used with the `STORES` variable.
 | Umart | AU | `umart`|
 | Unieuro | IT | `unieuro`|
 | Very | UK | `very`|
+| Vuugo | CA | `vuugo` |
 | Walmart | US | `walmart`|
 | Walmart | CA | `walmart-ca`|
 | Wipoid | ES | `wipoid`|

--- a/src/store/model/index.ts
+++ b/src/store/model/index.ts
@@ -101,6 +101,7 @@ import {Umart} from './umart';
 import {Unieuro} from './unieuro';
 import {Very} from './very';
 import {VsGamers} from './vsgamers';
+import {Vuugo} from './vuugo';
 import {Walmart} from './walmart';
 import {WalmartCa} from './walmart-ca';
 import {Wipoid} from './wipoid';
@@ -210,6 +211,7 @@ export const storeList = new Map([
 	[Unieuro.name, Unieuro],
 	[Very.name, Very],
 	[VsGamers.name, VsGamers],
+	[Vuugo.name, Vuugo],
 	[Walmart.name, Walmart],
 	[WalmartCa.name, WalmartCa],
 	[Wipoid.name, Wipoid],

--- a/src/store/model/store.ts
+++ b/src/store/model/store.ts
@@ -143,9 +143,9 @@ export type Model =
 	| 'xc3 black'
 	| 'xc3 ultra'
 	| 'xc3'
+	| 'xlr8 epicx'
 	| 'xlr8 revel'
-	| 'xlr8 uprising'
-	| 'xlr8 epic x';
+	| 'xlr8 uprising';
 
 export type Link = {
 	brand: Brand;

--- a/src/store/model/store.ts
+++ b/src/store/model/store.ts
@@ -78,6 +78,7 @@ export type Model =
 	| 'dual'
 	| 'eagle oc'
 	| 'eagle'
+	| 'ekwb'
 	| 'founders edition'
 	| 'ftw3'
 	| 'ftw3 ultra'
@@ -143,7 +144,8 @@ export type Model =
 	| 'xc3 ultra'
 	| 'xc3'
 	| 'xlr8 revel'
-	| 'xlr8 uprising';
+	| 'xlr8 uprising'
+	| 'xlr8 epic x';
 
 export type Link = {
 	brand: Brand;

--- a/src/store/model/store.ts
+++ b/src/store/model/store.ts
@@ -143,7 +143,7 @@ export type Model =
 	| 'xc3 black'
 	| 'xc3 ultra'
 	| 'xc3'
-	| 'xlr8 epicx'
+	| 'xlr8 epic x'
 	| 'xlr8 revel'
 	| 'xlr8 uprising';
 

--- a/src/store/model/vuugo.ts
+++ b/src/store/model/vuugo.ts
@@ -1,0 +1,724 @@
+import {Store} from './store';
+
+export const Vuugo: Store = {
+	currency: '$',
+	labels: {
+		inStock: {
+			container: '.green',
+			text: ['In Stock']
+		},
+		maxPrice: {
+			container: 'div.price:nth-child(12)'
+		}
+	},
+	links: [
+		{
+			brand: 'test:brand',
+			model: 'test:model',
+			series: 'test:series',
+			url:
+				'https://www.vuugo.com/computer-hardware/computer-parts/hard-drives/seagate-hard-drive-ST1000LM048.html'
+		},
+		{
+			brand: 'amd',
+			model: '5600x',
+			series: 'ryzen5600',
+			url:
+				'https://www.vuugo.com/computer-hardware/computer-parts/cpu/amd-cpu-100-100000065BOX.html'
+		},
+		{
+			brand: 'amd',
+			model: '5800x',
+			series: 'ryzen5800',
+			url:
+				'https://www.vuugo.com/computer-hardware/computer-parts/cpu/amd-cpu-100-100000063WOF.html'
+		},
+		{
+			brand: 'amd',
+			model: '5900x',
+			series: 'ryzen5900',
+			url:
+				'https://www.vuugo.com/computer-hardware/computer-parts/cpu/amd-cpu-100-100000061WOF.html'
+		},
+		{
+			brand: 'amd',
+			model: '5950x',
+			series: 'ryzen5950',
+			url:
+				'https://www.vuugo.com/computer-hardware/computer-parts/cpu/amd-cpu-100-100000059WOF.html'
+		},
+		{
+			brand: 'asrock',
+			model: 'amd reference',
+			series: 'rx6900xt',
+			url:
+				'https://www.vuugo.com/computer-hardware/computer-parts/video-cards/asrock-video-cards-RX6900XT-16G.html'
+		},
+		{
+			brand: 'asus',
+			model: 'dual oc',
+			series: '3060ti',
+			url:
+				'https://www.vuugo.com/computer-hardware/computer-parts/video-cards/asus-video-cards-DUAL-RTX3060TI-O8G.html'
+		},
+		{
+			brand: 'asus',
+			model: 'dual',
+			series: '3070',
+			url:
+				'https://www.vuugo.com/computer-hardware/computer-parts/video-cards/asus-video-cards-DUAL-RTX3070-8G.html'
+		},
+		{
+			brand: 'asus',
+			model: 'dual oc',
+			series: '3070',
+			url:
+				'https://www.vuugo.com/computer-hardware/computer-parts/video-cards/asus-video-cards-DUAL-RTX3070-O8G.html'
+		},
+		{
+			brand: 'asus',
+			model: 'strix oc',
+			series: '3060ti',
+			url:
+				'https://www.vuugo.com/computer-hardware/computer-parts/video-cards/asus-video-cards-ROG-STRIX-RTX3060TI-O8G-GAMING.html'
+		},
+		{
+			brand: 'asus',
+			model: 'ko',
+			series: '3070',
+			url:
+				'https://www.vuugo.com/computer-hardware/computer-parts/video-cards/asus-video-cards-KO-RTX3070-O8G-GAMING.html'
+		},
+		{
+			brand: 'asus',
+			model: 'strix oc',
+			series: '3070',
+			url:
+				'https://www.vuugo.com/computer-hardware/computer-parts/video-cards/asus-video-cards-ROG-STRIX-RTX3070-O8G-GAMING.html'
+		},
+		{
+			brand: 'asus',
+			model: 'strix oc',
+			series: '3070',
+			url:
+				'https://www.vuugo.com/computer-hardware/computer-parts/video-cards/asus-video-cards-ROG-STRIX-RTX3070-O8G-WH.html'
+		},
+		{
+			brand: 'asus',
+			model: 'strix oc',
+			series: '3080',
+			url:
+				'https://www.vuugo.com/computer-hardware/computer-parts/video-cards/asus-video-cards-ROG-STRIX-RTX3080-O10G-GAMING.html'
+		},
+		{
+			brand: 'asus',
+			model: 'strix oc',
+			series: '3080',
+			url:
+				'https://www.vuugo.com/computer-hardware/computer-parts/video-cards/asus-video-cards-ROG-STRIX-RTX3080-O10G-WH.html'
+		},
+		{
+			brand: 'asus',
+			model: 'strix oc',
+			series: '3090',
+			url:
+				'https://www.vuugo.com/computer-hardware/computer-parts/video-cards/asus-video-cards-ROG-STRIX-RTX3090-O24G-GA.html'
+		},
+		{
+			brand: 'asus',
+			model: 'strix oc',
+			series: '3090',
+			url:
+				'https://www.vuugo.com/computer-hardware/computer-parts/video-cards/asus-video-cards-ROG-STRIX-RTX3090-O24G-WH.html'
+		},
+		{
+			brand: 'asus',
+			model: 'strix lc',
+			series: 'rx6800xt',
+			url:
+				'https://www.vuugo.com/computer-hardware/computer-parts/video-cards/asus-video-cards-ROG-STRIX-LC-RX6800XT-O16G-GAMING.html'
+		},
+		{
+			brand: 'asus',
+			model: 'strix oc',
+			series: 'rx6800',
+			url:
+				'https://www.vuugo.com/computer-hardware/computer-parts/video-cards/asus-video-cards-ROG-STRIX-RX6800-O16G-GAMING.html'
+		},
+		{
+			brand: 'asus',
+			model: 'tuf oc',
+			series: '3060ti',
+			url:
+				'https://www.vuugo.com/computer-hardware/computer-parts/video-cards/asus-video-cards-TUF-RTX3060TI-O8G-GAMING.html'
+		},
+		{
+			brand: 'asus',
+			model: 'tuf oc',
+			series: '3070',
+			url:
+				'https://www.vuugo.com/computer-hardware/computer-parts/video-cards/asus-video-cards-TUF-RTX3070-O8G-GAMING.html'
+		},
+		{
+			brand: 'asus',
+			model: 'tuf',
+			series: '3080',
+			url:
+				'https://www.vuugo.com/computer-hardware/computer-parts/video-cards/asus-video-cards-TUF-RTX3080-10G-GAMING.html'
+		},
+		{
+			brand: 'asus',
+			model: 'tuf oc',
+			series: '3080',
+			url:
+				'https://www.vuugo.com/computer-hardware/computer-parts/video-cards/asus-video-cards-TUF-RTX3080-O10G-GAMING.html'
+		},
+		{
+			brand: 'asus',
+			model: 'tuf oc',
+			series: '3090',
+			url:
+				'https://www.vuugo.com/computer-hardware/computer-parts/video-cards/asus-video-cards-TUF-RTX3090-O24G-GAMING.html'
+		},
+		{
+			brand: 'asus',
+			model: 'tuf',
+			series: '3090',
+			url:
+				'https://www.vuugo.com/computer-hardware/computer-parts/video-cards/asus-video-cards-TUF-RTX3090-24G-GAMING.html'
+		},
+		{
+			brand: 'asus',
+			model: 'ekwb',
+			series: '3090',
+			url:
+				'https://www.vuugo.com/computer-hardware/computer-parts/video-cards/asus-video-cards-RTX3090-24G-EK.html'
+		},
+		{
+			brand: 'asus',
+			model: 'ekwb',
+			series: '3080',
+			url:
+				'https://www.vuugo.com/computer-hardware/computer-parts/video-cards/asus-video-cards-RTX3080-10G-EK.html'
+		},
+		{
+			brand: 'asus',
+			model: 'tuf oc',
+			series: 'rx6800',
+			url:
+				'https://www.vuugo.com/computer-hardware/computer-parts/video-cards/asus-video-cards-TUF-RX6800-O16G-GAMING.html'
+		},
+		{
+			brand: 'asus',
+			model: 'tuf oc',
+			series: 'rx6800xt',
+			url:
+				'https://www.vuugo.com/computer-hardware/computer-parts/video-cards/asus-video-cards-TUF-RX6800XT-O16G-GAMING.html'
+		},
+		{
+			brand: 'asus',
+			model: 'tuf oc',
+			series: 'rx6900xt',
+			url:
+				'https://www.vuugo.com/computer-hardware/computer-parts/video-cards/asus-video-cards-TUF-RX6900XT-O16G-GAMING.html'
+		},
+		{
+			brand: 'evga',
+			model: 'ftw3 ultra',
+			series: '3060ti',
+			url:
+				'https://www.vuugo.com/computer-hardware/computer-parts/video-cards/evga-video-cards-08G-P5-3667-KR.html'
+		},
+		{
+			brand: 'evga',
+			model: 'xc gaming',
+			series: '3060ti',
+			url:
+				'https://www.vuugo.com/computer-hardware/computer-parts/video-cards/evga-video-cards-08G-P5-3663-KR.html'
+		},
+		{
+			brand: 'evga',
+			model: 'ftw3',
+			series: '3070',
+			url:
+				'https://www.vuugo.com/computer-hardware/computer-parts/video-cards/evga-video-cards-08G-P5-3765-KR.html'
+		},
+		{
+			brand: 'evga',
+			model: 'ftw3 ultra',
+			series: '3070',
+			url:
+				'https://www.vuugo.com/computer-hardware/computer-parts/video-cards/evga-video-cards-08G-P5-3767-KR.html'
+		},
+		{
+			brand: 'evga',
+			model: 'xc3 black',
+			series: '3070',
+			url:
+				'https://www.vuugo.com/computer-hardware/computer-parts/video-cards/evga-video-cards-08G-P5-3751-KR.html'
+		},
+		{
+			brand: 'evga',
+			model: 'xc3',
+			series: '3070',
+			url:
+				'https://www.vuugo.com/computer-hardware/computer-parts/video-cards/evga-video-cards-08G-P5-3753-KR.html'
+		},
+		{
+			brand: 'evga',
+			model: 'xc3 ultra',
+			series: '3070',
+			url:
+				'https://www.vuugo.com/computer-hardware/computer-parts/video-cards/evga-video-cards-08G-P5-3755-KR.html'
+		},
+		{
+			brand: 'evga',
+			model: 'ftw3',
+			series: '3080',
+			url:
+				'https://www.vuugo.com/computer-hardware/computer-parts/video-cards/evga-video-cards-10G-P5-3895-KR.html'
+		},
+		{
+			brand: 'evga',
+			model: 'ftw3 ultra',
+			series: '3080',
+			url:
+				'https://www.vuugo.com/computer-hardware/computer-parts/video-cards/evga-video-cards-10G-P5-3897-KR.html'
+		},
+		{
+			brand: 'evga',
+			model: 'xc3 black',
+			series: '3080',
+			url:
+				'https://www.vuugo.com/computer-hardware/computer-parts/video-cards/evga-video-cards-10G-P5-3881-KR.html'
+		},
+		{
+			brand: 'evga',
+			model: 'xc3',
+			series: '3080',
+			url:
+				'https://www.vuugo.com/computer-hardware/computer-parts/video-cards/evga-video-cards-10G-P5-3883-KR.html'
+		},
+		{
+			brand: 'evga',
+			model: 'xc3 ultra',
+			series: '3080',
+			url:
+				'https://www.vuugo.com/computer-hardware/computer-parts/video-cards/evga-video-cards-10G-P5-3885-KR.html'
+		},
+		{
+			brand: 'evga',
+			model: 'ftw3',
+			series: '3090',
+			url:
+				'https://www.vuugo.com/computer-hardware/computer-parts/video-cards/evga-video-cards-24G-P5-3985-KR.html'
+		},
+		{
+			brand: 'evga',
+			model: 'ftw3 ultra',
+			series: '3090',
+			url:
+				'https://www.vuugo.com/computer-hardware/computer-parts/video-cards/evga-video-cards-24G-P5-3987-KR.html'
+		},
+		{
+			brand: 'evga',
+			model: 'xc3',
+			series: '3090',
+			url:
+				'https://www.vuugo.com/computer-hardware/computer-parts/video-cards/evga-video-cards-24G-P5-3973-KR.html'
+		},
+		{
+			brand: 'evga',
+			model: 'xc3 ultra',
+			series: '3090',
+			url:
+				'https://www.vuugo.com/computer-hardware/computer-parts/video-cards/evga-video-cards-24G-P5-3975-KR.html'
+		},
+		{
+			brand: 'gigabyte',
+			model: 'aorus master',
+			series: '3060ti',
+			url:
+				'https://www.vuugo.com/computer-hardware/computer-parts/video-cards/gigabyte-video-cards-GV-N306TAORUS-M-8GD.html'
+		},
+		{
+			brand: 'gigabyte',
+			model: 'aorus master',
+			series: '3070',
+			url:
+				'https://www.vuugo.com/computer-hardware/computer-parts/video-cards/gigabyte-video-cards-GV-N3070AORUS%20M-8GD.html'
+		},
+		{
+			brand: 'gigabyte',
+			model: 'aorus master',
+			series: '3080',
+			url:
+				'https://www.vuugo.com/computer-hardware/computer-parts/video-cards/gigabyte-video-cards-GV-N3080AORUS-M-10GD.html'
+		},
+		{
+			brand: 'gigabyte',
+			model: 'aorus master',
+			series: '3090',
+			url:
+				'https://www.vuugo.com/computer-hardware/computer-parts/video-cards/gigabyte-video-cards-GV-N3090AORUS-M-24GD.html'
+		},
+		{
+			brand: 'gigabyte',
+			model: 'aorus xtreme',
+			series: '3080',
+			url:
+				'https://www.vuugo.com/computer-hardware/computer-parts/video-cards/gigabyte-video-cards-GV-N3080AORUS-X-10GD.html'
+		},
+		{
+			brand: 'gigabyte',
+			model: 'aorus xtreme',
+			series: '3090',
+			url:
+				'https://www.vuugo.com/computer-hardware/computer-parts/video-cards/gigabyte-video-cards-GV-N3090AORUS-X-24GD.html'
+		},
+		{
+			brand: 'gigabyte',
+			model: 'eagle',
+			series: '3060ti',
+			url:
+				'https://www.vuugo.com/computer-hardware/computer-parts/video-cards/gigabyte-video-cards-GV-N306TEAGLE-8GD.html'
+		},
+		{
+			brand: 'gigabyte',
+			model: 'eagle oc',
+			series: '3060ti',
+			url:
+				'https://www.vuugo.com/computer-hardware/computer-parts/video-cards/gigabyte-video-cards-GV-N306TEAGLE-OC-8GD.html'
+		},
+		{
+			brand: 'gigabyte',
+			model: 'gaming oc',
+			series: '3060ti',
+			url:
+				'https://www.vuugo.com/computer-hardware/computer-parts/video-cards/gigabyte-video-cards-GV-N306TGAMING-OC-8GD.html'
+		},
+		{
+			brand: 'gigabyte',
+			model: 'gaming oc pro',
+			series: '3060ti',
+			url:
+				'https://www.vuugo.com/computer-hardware/computer-parts/video-cards/gigabyte-video-cards-GV-N306TGAMINGOC-PRO-8GD.html'
+		},
+		{
+			brand: 'gigabyte',
+			model: 'eagle',
+			series: '3070',
+			url:
+				'https://www.vuugo.com/computer-hardware/computer-parts/video-cards/gigabyte-video-cards-GV-N3070EAGLE-8GD.html'
+		},
+		{
+			brand: 'gigabyte',
+			model: 'eagle oc',
+			series: '3070',
+			url:
+				'https://www.vuugo.com/computer-hardware/computer-parts/video-cards/gigabyte-video-cards-GV-N3070EAGLE-OC-8GD.html'
+		},
+		{
+			brand: 'gigabyte',
+			model: 'gaming oc',
+			series: '3070',
+			url:
+				'https://www.vuugo.com/computer-hardware/computer-parts/video-cards/gigabyte-video-cards-GV-N3070GAMING-OC-8GD.html'
+		},
+		{
+			brand: 'gigabyte',
+			model: 'eagle',
+			series: '3080',
+			url:
+				'https://www.vuugo.com/computer-hardware/computer-parts/video-cards/gigabyte-video-cards-GV-N3080EAGLE-10GD.html'
+		},
+		{
+			brand: 'gigabyte',
+			model: 'eagle oc',
+			series: '3080',
+			url:
+				'https://www.vuugo.com/computer-hardware/computer-parts/video-cards/gigabyte-video-cards-GV-N3080EAGLE-OC-10GD.html'
+		},
+		{
+			brand: 'gigabyte',
+			model: 'gaming oc',
+			series: '3080',
+			url:
+				'https://www.vuugo.com/computer-hardware/computer-parts/video-cards/gigabyte-video-cards-GV-N3080GAMING-OC-10GD.html'
+		},
+		{
+			brand: 'gigabyte',
+			model: 'vision oc',
+			series: '3080',
+			url:
+				'https://www.vuugo.com/computer-hardware/computer-parts/video-cards/gigabyte-video-cards-GV-N3080VISION-OC-10GD.html'
+		},
+		{
+			brand: 'gigabyte',
+			model: 'eagle',
+			series: '3090',
+			url:
+				'https://www.vuugo.com/computer-hardware/computer-parts/video-cards/gigabyte-video-cards-GV-N3090EAGLE-24GD.html'
+		},
+		{
+			brand: 'gigabyte',
+			model: 'eagle oc',
+			series: '3090',
+			url:
+				'https://www.vuugo.com/computer-hardware/computer-parts/video-cards/gigabyte-video-cards-GV-N3090EAGLE-OC-24GD.html'
+		},
+		{
+			brand: 'gigabyte',
+			model: 'gaming oc',
+			series: '3090',
+			url:
+				'https://www.vuugo.com/computer-hardware/computer-parts/video-cards/gigabyte-video-cards-GV-N3090GAMING-OC-24GD.html'
+		},
+		{
+			brand: 'gigabyte',
+			model: 'vision oc',
+			series: '3090',
+			url:
+				'https://www.vuugo.com/computer-hardware/computer-parts/video-cards/gigabyte-video-cards-GV-N3090VISION-OC-24GD.html'
+		},
+		{
+			brand: 'gigabyte',
+			model: 'vision oc',
+			series: '3070',
+			url:
+				'https://www.vuugo.com/computer-hardware/computer-parts/video-cards/gigabyte-video-cards-GV-N3070VISION-OC-8GD.html'
+		},
+		{
+			brand: 'gigabyte',
+			model: 'gaming oc',
+			series: 'rx6800',
+			url:
+				'https://www.vuugo.com/computer-hardware/computer-parts/video-cards/gigabyte-video-cards-GV-R68GAMING-OC-16GD.html'
+		},
+		{
+			brand: 'gigabyte',
+			model: 'gaming oc',
+			series: 'rx6800xt',
+			url:
+				'https://www.vuugo.com/computer-hardware/computer-parts/video-cards/gigabyte-video-cards-GV-R68XTGAMING-OC-16GD.html'
+		},
+		{
+			brand: 'msi',
+			model: 'gaming x trio',
+			series: '3060ti',
+			url:
+				'https://www.vuugo.com/computer-hardware/computer-parts/video-cards/msi-video-cards-G306TGXT.html'
+		},
+		{
+			brand: 'msi',
+			model: 'ventus 2x oc',
+			series: '3060ti',
+			url:
+				'https://www.vuugo.com/computer-hardware/computer-parts/video-cards/msi-video-cards-G306TV2XC.html'
+		},
+		{
+			brand: 'msi',
+			model: 'gaming x trio',
+			series: '3070',
+			url:
+				'https://www.vuugo.com/computer-hardware/computer-parts/video-cards/msi-video-cards-G3070GXT.html'
+		},
+		{
+			brand: 'msi',
+			model: 'suprim x',
+			series: '3070',
+			url:
+				'https://www.vuugo.com/computer-hardware/computer-parts/video-cards/msi-video-cards-G3070SX8.html'
+		},
+		{
+			brand: 'msi',
+			model: 'ventus 2x oc',
+			series: '3070',
+			url:
+				'https://www.vuugo.com/computer-hardware/computer-parts/video-cards/msi-video-cards-G3070V2XC.html'
+		},
+		{
+			brand: 'msi',
+			model: 'ventus 3x oc',
+			series: '3070',
+			url:
+				'https://www.vuugo.com/computer-hardware/computer-parts/video-cards/msi-video-cards-G3070V3XC.html'
+		},
+		{
+			brand: 'msi',
+			model: 'gaming x trio',
+			series: '3080',
+			url:
+				'https://www.vuugo.com/computer-hardware/computer-parts/video-cards/msi-video-cards-G3080GXT10.html'
+		},
+		{
+			brand: 'msi',
+			model: 'ventus 3x oc',
+			series: '3080',
+			url:
+				'https://www.vuugo.com/computer-hardware/computer-parts/video-cards/msi-video-cards-G3080V3X10C.html'
+		},
+		{
+			brand: 'msi',
+			model: 'gaming x trio',
+			series: '3090',
+			url:
+				'https://www.vuugo.com/computer-hardware/computer-parts/video-cards/msi-video-cards-G3090GXT24.html'
+		},
+		{
+			brand: 'msi',
+			model: 'ventus 3x oc',
+			series: '3090',
+			url:
+				'https://www.vuugo.com/computer-hardware/computer-parts/video-cards/msi-video-cards-G3090V3X24C.html'
+		},
+		{
+			brand: 'msi',
+			model: 'amd reference',
+			series: 'rx6800xt',
+			url:
+				'https://www.vuugo.com/computer-hardware/computer-parts/video-cards/msi-video-cards-R6800GXT16.html'
+		},
+		{
+			brand: 'msi',
+			model: 'gaming x trio',
+			series: 'rx6800xt',
+			url:
+				'https://www.vuugo.com/computer-hardware/computer-parts/video-cards/msi-video-cards-R6800XTGXT16.html'
+		},
+		{
+			brand: 'pny',
+			model: 'xlr8 revel',
+			series: '3060ti',
+			url:
+				'https://www.vuugo.com/computer-hardware/computer-parts/video-cards/pny-video-cards-VCG3060T8DFXPPB.html'
+		},
+		{
+			brand: 'pny',
+			model: 'xlr8 revel',
+			series: '3070',
+			url:
+				'https://www.vuugo.com/computer-hardware/computer-parts/video-cards/pny-video-cards-VCG30708TFXPPB.html'
+		},
+		{
+			brand: 'pny',
+			model: 'dual fan',
+			series: '3070',
+			url:
+				'https://www.vuugo.com/computer-hardware/computer-parts/video-cards/pny-video-cards-VCG30708DFMPB.html'
+		},
+		{
+			brand: 'pny',
+			model: 'xlr8 revel',
+			series: '3090',
+			url:
+				'https://www.vuugo.com/computer-hardware/computer-parts/video-cards/pny-video-cards-VCG309024TFXPPB.html'
+		},
+		{
+			brand: 'pny',
+			model: 'xlr8 uprising',
+			series: '3080',
+			url:
+				'https://www.vuugo.com/computer-hardware/computer-parts/video-cards/pny-video-cards-VCG308010TFXMPB.html'
+		},
+		{
+			brand: 'pny',
+			model: 'xlr8 epic x',
+			series: '3080',
+			url:
+				'https://www.vuugo.com/computer-hardware/computer-parts/video-cards/pny-video-cards-VCG308010TFXPPB.html'
+		},
+		{
+			brand: 'pny',
+			model: 'xlr8 epic x',
+			series: '3090',
+			url:
+				'https://www.vuugo.com/computer-hardware/computer-parts/video-cards/pny-video-cards-VCG309024TFXMPB.html'
+		},
+		{
+			brand: 'sapphire',
+			model: 'nitro+',
+			series: 'rx6800',
+			url:
+				'https://www.vuugo.com/computer-hardware/computer-parts/video-cards/sapphire-video-cards-11305-01-20G.html'
+		},
+		{
+			brand: 'sapphire',
+			model: 'nitro+',
+			series: 'rx6800xt',
+			url:
+				'https://www.vuugo.com/computer-hardware/computer-parts/video-cards/sapphire-video-cards-11304-02-20G.html'
+		},
+		{
+			brand: 'sapphire',
+			model: 'nitro+ se',
+			series: 'rx6800xt',
+			url:
+				'https://www.vuugo.com/computer-hardware/computer-parts/video-cards/sapphire-video-cards-11304-01-20G.html'
+		},
+		{
+			brand: 'sapphire',
+			model: 'pulse',
+			series: 'rx6800',
+			url:
+				'https://www.vuugo.com/computer-hardware/computer-parts/video-cards/sapphire-video-cards-11305-02-20G.html'
+		},
+		{
+			brand: 'sapphire',
+			model: 'pulse',
+			series: 'rx6800xt',
+			url:
+				'https://www.vuugo.com/computer-hardware/computer-parts/video-cards/sapphire-video-cards-11304-03-20G.html'
+		},
+		{
+			brand: 'sapphire',
+			model: 'amd reference',
+			series: 'rx6800',
+			url:
+				'https://www.vuugo.com/computer-hardware/computer-parts/video-cards/sapphire-video-cards-21305-01-20G.html'
+		},
+		{
+			brand: 'sapphire',
+			model: 'amd reference',
+			series: 'rx6800xt',
+			url:
+				'https://www.vuugo.com/computer-hardware/computer-parts/video-cards/sapphire-video-cards-21304-01-20G.html'
+		},
+		{
+			brand: 'zotac',
+			model: 'twin edge oc',
+			series: '3070',
+			url:
+				'https://www.vuugo.com/computer-hardware/computer-parts/video-cards/zotac-video-cards-ZT-A30700H-10P.html'
+		},
+		{
+			brand: 'zotac',
+			model: 'twin edge',
+			series: '3070',
+			url:
+				'https://www.vuugo.com/computer-hardware/computer-parts/video-cards/zotac-video-cards-ZT-A30700E-10P.html'
+		},
+		{
+			brand: 'zotac',
+			model: 'trinity oc',
+			series: '3080',
+			url:
+				'https://www.vuugo.com/computer-hardware/computer-parts/video-cards/zotac-video-cards-ZT-A30800J-10P.html'
+		},
+		{
+			brand: 'zotac',
+			model: 'trinity',
+			series: '3080',
+			url:
+				'https://www.vuugo.com/computer-hardware/computer-parts/video-cards/zotac-video-cards-ZT-A30800D-10P.html'
+		},
+		{
+			brand: 'zotac',
+			model: 'trinity',
+			series: '3090',
+			url:
+				'https://www.vuugo.com/computer-hardware/computer-parts/video-cards/zotac-video-cards-ZT-A30900D-10P.html'
+		}
+	],
+	name: 'vuugo'
+};


### PR DESCRIPTION
### Description

Added an additional Canadian store Vuugo with support for all available RTX 3000 series, RX 6000 series and Ryzen 5000 series components.

Also added two additional GPU Models which were available at Vuugo but not previously added

- [Asus EKWB](https://www.vuugo.com/computer-hardware/computer-parts/video-cards/asus-video-cards-RTX3080-10G-EK.html)
- [PNY XLR8 Epic-X](https://www.vuugo.com/computer-hardware/computer-parts/video-cards/pny-video-cards-VCG308010TFXPPB.html)

### Testing

Edited the env confirmation to add the new store:
```
...  
STORES=vuugo  
...
```

Ran the application to verify stock was checked including the test item
```
[2:51:22 p.m.] info :: 🚀🚨 [vuugo] [test:brand (test:series)] test:model :: IN STOCK 🚨🚀  
https://www.vuugo.com/computer-hardware/computer-parts/hard-drives/seagate-hard-drive-ST1000LM048.html  
[2:51:25 p.m.] info :: ✖ [vuugo] [asrock (rx6900xt)] amd reference :: OUT OF STOCK  
[2:51:27 p.m.] info :: ✖ [vuugo] [asus (3060ti)] dual oc :: OUT OF STOCK  
[2:51:30 p.m.] info :: ✖ [vuugo] [asus (3070)] dual :: OUT OF STOCK  
[2:51:33 p.m.] info :: ✖ [vuugo] [asus (3070)] dual oc :: OUT OF STOCK  
[2:51:35 p.m.] info :: ✖ [vuugo] [asus (3060ti)] strix oc :: OUT OF STOCK  
[2:51:38 p.m.] info :: ✖ [vuugo] [asus (3070)] ko :: OUT OF STOCK
```

I've also fixed all lint errors which were identified
<!-- Please describe the tests that you ran to verify your changes. -->
<!-- Provide instructions so we can reproduce. -->
<!-- Please also list any relevant details for your test configuration -->
