### PR TITLE
feat: Added support for RegEx in inStock/outOfStock labels

### DIFF
--- a/src/store/includes-labels.ts
+++ b/src/store/includes-labels.ts
@@ -21,7 +21,8 @@ function getQueryAsElementArray(
 	if (isElementArray(query)) {
 		return query.map((x) => ({
 			container: x.container ?? defaultContainer,
-			text: x.text
+			regex: x.regex ?? [],
+			text: x.text ?? []
 		}));
 	}
 
@@ -29,6 +30,7 @@ function getQueryAsElementArray(
 		return [
 			{
 				container: defaultContainer,
+				regex: [],
 				text: query
 			}
 		];
@@ -37,7 +39,8 @@ function getQueryAsElementArray(
 	return [
 		{
 			container: query.container ?? defaultContainer,
-			text: query.text
+			regex: query.regex ?? [],
+			text: query.text ?? []
 		}
 	];
 }
@@ -60,7 +63,10 @@ export async function pageIncludesLabels(
 
 			logger.debug(contents);
 
-			return includesLabels(contents, query.text);
+			return (
+				includesLabels(contents, query.text) ||
+				includesRegex(contents, query.regex)
+			);
 		})
 	);
 
@@ -114,6 +120,19 @@ export function includesLabels(
 	return searchLabels.some((label) =>
 		domTextLowerCase.includes(label.toLowerCase())
 	);
+}
+
+/**
+ * Checks if DOM has any text matching a regex.
+ *
+ * @param domText Complete DOM of website.
+ * @param regexStrings Regex strings to search for a match.
+ */
+export function includesRegex(
+	domText: string,
+	regexStrings: RegExp[]
+): boolean {
+	return regexStrings.some((regex) => regex.test(domText));
 }
 
 export async function getPrice(

--- a/src/store/model/memoryexpress.ts
+++ b/src/store/model/memoryexpress.ts
@@ -3,15 +3,15 @@ import {Store} from './store';
 export const MemoryExpress: Store = {
 	currency: '$',
 	labels: {
+		inStock: {
+			container:
+				'.c-capr-inventory-selector__details-online .c-capr-inventory-store__availability',
+			regex: [/\d+\+?/]
+		},
 		maxPrice: {
 			container:
 				'#ProductPricing .GrandTotal.c-capr-pricing__grand-total > div',
 			euroFormat: false
-		},
-		outOfStock: {
-			container:
-				'.c-capr-inventory-selector__details-online .c-capr-inventory-store__availability',
-			text: ['Out of Stock', 'Backorder']
 		}
 	},
 	links: [
@@ -19,7 +19,7 @@ export const MemoryExpress: Store = {
 			brand: 'test:brand',
 			model: 'test:model',
 			series: 'test:series',
-			url: 'https://www.memoryexpress.com/Products/MX79473'
+			url: 'https://www.memoryexpress.com/Products/MX73448'
 		},
 		{
 			brand: 'msi',

--- a/src/store/model/store.ts
+++ b/src/store/model/store.ts
@@ -2,7 +2,8 @@ import {Browser, LoadEvent} from 'puppeteer';
 
 export type Element = {
 	container?: string;
-	text: string[];
+	text?: string[];
+	regex?: RegExp[];
 };
 
 export type Pricing = {


### PR DESCRIPTION
<!-- Please use Conventional Commits to label your title -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/ -->
<!-- Example: feat: allow provided config object to extend other configs  -->

### Description

Added the ability to make a list of regex string to search for a site as opposed to only allowing text searches. A new key was added to the `Element` type which allows for an array of `RegExp`to be provided in the store configurations. The new feature has been applied to memoryexpress.ts as this store requires the functionality. The test item in Memoryexpress has also been changed since the 1660 Super used before is no longer in stock

As noted in #1246 and #877, Memoryexpress does not serve it's 500 error messaged in a non HTTP compliant fashion, they perform a redirect to their error page (Resulting in 301 and 200 status codes). As a result of this, the current "outOfStock" search causes false positives when the site crashes (quite frequently). The issue mentions a change to memoryexpress.ts to use the inStock label against the add to cart button. Recently, it seems the site has changed to always show the add to cart button while a product is not in stock.

The only two options to fix the issue I could think of was

1. Add exclusion text to the search term (Return true when "Out of Stock" is not found except when "[500 - Server Error](https://imgur.com/a/3clFEYL)" is present)
2. Add the ability to search for a dynamic value in a specific selector as opposed to a static string

I assumed the 2nd option would be a more useful feature. The implementation closely follows the current text implementation in an additional function call. In addition, the `text` and `regex` attributes of the `Element` type have been made optional. 

fixes #1588 

### Testing

Added memoryexpress and amazon-ca as stores in the environment file, as well as a few series (including the test series), all brands and all models.

Allowed the bot to run and confirmed both test items (memoryexpress and amazon-ca) appear as in stock and notifications are sent, out of stock items are also correctly identified as out of stock. I've allowed the bot to run for some time and have not identified any issues.

All results from the linter has also been cleaned up.