### PR TITLE
Bugfix Galaxus, updated to .ZZf1 from old entry

### DIFF
--- a/src/store/model/galaxus.ts
+++ b/src/store/model/galaxus.ts
@@ -8,7 +8,7 @@ export const Galaxus: Store = {
 			text: ['In den Warenkorb']
 		},
 		maxPrice: {
-			container: '.productDetail .ZZ92',
+			container: '.productDetail .ZZf1',
 			euroFormat: true
 		}
 	},


### PR DESCRIPTION
 Galaxus changed again the html class for the prices.

### Description
Update to #1469 from KnotenJoe 

Changed to  class .ZZf1 

### Testing

Galaxus gave false positives for AMD Princings, ignoring pricing at all. After patch pricing was checked / displayed correctly again.

