### PR TITLE
fix(store): update missing/mislabeled cards for Canadian retailers

### DIFF
--- a/src/store/model/bestbuy-ca.ts
+++ b/src/store/model/bestbuy-ca.ts
@@ -18,7 +18,7 @@ export const BestBuyCa: Store = {
 			model: 'test:model',
 			series: 'test:series',
 			url:
-				'https://www.bestbuy.ca/en-ca/product/zotac-nvidia-geforce-gtx-1660-super-twin-fan-6gb-gddr6-video-card/14415897'
+				'https://www.bestbuy.ca/en-ca/product/google-nest-hello-wi-fi-video-doorbell-black-white/12222651'
 		},
 		{
 			brand: 'msi',
@@ -42,13 +42,6 @@ export const BestBuyCa: Store = {
 				'https://www.bestbuy.ca/en-ca/product/zotac-geforce-rtx-3060-ti-twin-edge-oc-8gb-gddr6-video-card/15178452?intl=nosplash'
 		},
 		{
-			brand: 'zotac',
-			model: 'twin edge',
-			series: '3060ti',
-			url:
-				'https://www.bestbuy.ca/en-ca/product/zotac-geforce-rtx-3060-ti-twin-edge-8gb-gddr6-video-card/15178583?intl=nosplash'
-		},
-		{
 			brand: 'evga',
 			model: 'ftw3 ultra',
 			series: '3060ti',
@@ -63,6 +56,13 @@ export const BestBuyCa: Store = {
 				'https://www.bestbuy.ca/en-ca/product/zotac-geforce-rtx-3080-trinity-10gb-gddr6x-video-card/14953249?intl=nosplash'
 		},
 		{
+			brand: 'zotac',
+			model: 'trinity oc',
+			series: '3080',
+			url:
+				'https://www.bestbuy.ca/en-ca/product/zotac-nvidia-geforce-rtx-3080-trinity-oc-10gb-gddr6x-video-card/15000077?intl=nosplash'
+		},
+		{
 			brand: 'msi',
 			model: 'ventus 3x',
 			series: '3080',
@@ -75,6 +75,13 @@ export const BestBuyCa: Store = {
 			series: '3080',
 			url:
 				'https://www.bestbuy.ca/en-ca/product/evga-geforce-rtx-3080-xc3-ultra-gaming-10gb-gddr6x-video-card/15084753?intl=nosplash'
+		},
+		{
+			brand: 'evga',
+			model: 'xc3 ultra',
+			series: '3080',
+			url:
+				'https://www.bestbuy.ca/en-ca/product/evga-geforce-rtx-3080-xc3-ultra-gaming-10gb-gddr6x-video-card-english/14961449?intl=nosplash'
 		},
 		{
 			brand: 'asus',
@@ -113,14 +120,21 @@ export const BestBuyCa: Store = {
 		},
 		{
 			brand: 'msi',
-			model: 'ventus 3x',
+			model: 'ventus 3x oc',
 			series: '3090',
 			url:
 				'https://www.bestbuy.ca/en-ca/product/msi-nvidia-geforce-rtx-3090-ventus-3x-oc-24gb-gddr6x-video-card/14966477?intl=nosplash'
 		},
 		{
+			brand: 'evga',
+			model: 'xc3 ultra',
+			series: '3090',
+			url:
+				'https://www.bestbuy.ca/en-ca/product/evga-nvidia-geforce-rtx-3090-xc3-ultra-gaming-24gb-gddr6x-video-card/14967857?intl=nosplash'
+		},
+		{
 			brand: 'msi',
-			model: 'ventus 3x',
+			model: 'ventus 3x oc',
 			series: '3070',
 			url:
 				'https://www.bestbuy.ca/en-ca/product/msi-nvidia-geforce-rtx-3070-ventus-3x-oc-8gb-gddr6x-video-card/15038016?intl=nosplash'
@@ -145,6 +159,20 @@ export const BestBuyCa: Store = {
 			series: '3070',
 			url:
 				'https://www.bestbuy.ca/en-ca/product/nvidia-geforce-rtx-3070-8gb-gddr6-video-card-only-at-best-buy/15078017?intl=nosplash'
+		},
+		{
+			brand: 'evga',
+			model: 'xc3 ultra',
+			series: '3070',
+			url:
+				'https://www.bestbuy.ca/en-ca/product/evga-geforce-rtx-3070-xc3-ultra-8gb-gddr6-video-card/15147122?intl=nosplash'
+		},
+		{
+			brand: 'evga',
+			model: 'xc3 black',
+			series: '3070',
+			url:
+				'https://www.bestbuy.ca/en-ca/product/evga-geforce-rtx-3070-xc3-black-8gb-gddr6-video-card/15081879?intl=nosplash'
 		},
 		{
 			brand: 'sony',

--- a/src/store/model/canadacomputers.ts
+++ b/src/store/model/canadacomputers.ts
@@ -7,9 +7,9 @@ export const CanadaComputers: Store = {
 			container: 'div[class="pi-prod-availability"]',
 			text: ['Online In Stock']
 		},
-		outOfStock: {
-			container: 'div[class="pi-prod-availability"]',
-			text: ['Not Available Online']
+		maxPrice: {
+			container: '.h2-big > strong:nth-child(1)',
+			euroFormat: false
 		}
 	},
 	links: [

--- a/src/store/model/canadacomputers.ts
+++ b/src/store/model/canadacomputers.ts
@@ -18,7 +18,7 @@ export const CanadaComputers: Store = {
 			model: 'test:model',
 			series: 'test:series',
 			url:
-				'https://www.canadacomputers.com/product_info.php?cPath=43_557_559&item_id=181348&language=en'
+				'https://www.canadacomputers.com/product_info.php?item_id=167320&cPath=27_1046_365&language=en'
 		},
 		{
 			brand: 'gigabyte',
@@ -47,13 +47,6 @@ export const CanadaComputers: Store = {
 			series: '3070',
 			url:
 				'https://www.canadacomputers.com/product_info.php?cPath=43_557_559&item_id=183210&language=en'
-		},
-		{
-			brand: 'asus',
-			model: 'dual',
-			series: '3070',
-			url:
-				'https://www.canadacomputers.com/product_info.php?cPath=43_557_559&item_id=183635&language=en'
 		},
 		{
 			brand: 'asus',
@@ -91,6 +84,13 @@ export const CanadaComputers: Store = {
 				'https://www.canadacomputers.com/product_info.php?cPath=43_557_559&item_id=183561&language=en'
 		},
 		{
+			brand: 'zotac',
+			model: 'twin edge oc',
+			series: '3070',
+			url:
+				'https://www.canadacomputers.com/product_info.php?cPath=43_557_559&item_id=185675&language=en'
+		},
+		{
 			brand: 'msi',
 			model: 'ventus 2x oc',
 			series: '3070',
@@ -106,7 +106,7 @@ export const CanadaComputers: Store = {
 		},
 		{
 			brand: 'asus',
-			model: 'gaming oc',
+			model: 'tuf oc',
 			series: '3070',
 			url:
 				'https://www.canadacomputers.com/product_info.php?cPath=43_557_559&item_id=183638&language=en'
@@ -140,11 +140,18 @@ export const CanadaComputers: Store = {
 				'https://www.canadacomputers.com/product_info.php?cPath=43_557_559&item_id=183499&language=en'
 		},
 		{
-			brand: 'asus',
-			model: 'gaming',
+			brand: 'msi',
+			model: 'suprim x',
 			series: '3070',
 			url:
-				'https://www.canadacomputers.com/product_info.php?cPath=43_557_559&item_id=184743&language=en'
+				'https://www.canadacomputers.com/product_info.php?cPath=43_557_559&item_id=186197&language=en'
+		},
+		{
+			brand: 'asus',
+			model: 'strix oc',
+			series: '3070',
+			url:
+				'https://www.canadacomputers.com/product_info.php?cPath=43_557_559&item_id=186310&language=en'
 		},
 		{
 			brand: 'evga',
@@ -175,13 +182,6 @@ export const CanadaComputers: Store = {
 				'https://www.canadacomputers.com/product_info.php?cPath=43_557_559&item_id=181354&language=en'
 		},
 		{
-			brand: 'asus',
-			model: 'gaming',
-			series: '3080',
-			url:
-				'https://www.canadacomputers.com/product_info.php?cPath=43_557_559&item_id=181416&language=en'
-		},
-		{
 			brand: 'evga',
 			model: 'xc3 ultra',
 			series: '3080',
@@ -204,7 +204,7 @@ export const CanadaComputers: Store = {
 		},
 		{
 			brand: 'asus',
-			model: 'gaming oc',
+			model: 'tuf oc',
 			series: '3080',
 			url:
 				'https://www.canadacomputers.com/product_info.php?cPath=43_557_559&item_id=181415&language=en'
@@ -215,13 +215,6 @@ export const CanadaComputers: Store = {
 			series: '3080',
 			url:
 				'https://www.canadacomputers.com/product_info.php?cPath=43_557_559&item_id=181353&language=en'
-		},
-		{
-			brand: 'asus',
-			model: 'gaming',
-			series: '3080',
-			url:
-				'https://www.canadacomputers.com/product_info.php?cPath=43_557_559&item_id=184743&language=en'
 		},
 		{
 			brand: 'msi',
@@ -281,6 +274,34 @@ export const CanadaComputers: Store = {
 		},
 		{
 			brand: 'asus',
+			model: 'strix',
+			series: '3080',
+			url:
+				'https://www.canadacomputers.com/product_info.php?cPath=43_557_559&item_id=186309&language=en'
+		},
+		{
+			brand: 'msi',
+			model: 'suprim x',
+			series: '3080',
+			url:
+				'https://www.canadacomputers.com/product_info.php?cPath=43_557_559&item_id=185084&language=en'
+		},
+		{
+			brand: 'gigabyte',
+			model: 'aorus xtreme waterforce wb',
+			series: '3080',
+			url:
+				'https://www.canadacomputers.com/product_info.php?cPath=43_557_559&item_id=186345&language=en'
+		},
+		{
+			brand: 'gigabyte',
+			model: 'aorus xtreme waterforce wb',
+			series: '3080',
+			url:
+				'https://www.canadacomputers.com/product_info.php?cPath=43_557_559&item_id=186344&language=en'
+		},
+		{
+			brand: 'asus',
 			model: 'strix oc',
 			series: '3090',
 			url:
@@ -295,7 +316,7 @@ export const CanadaComputers: Store = {
 		},
 		{
 			brand: 'asus',
-			model: 'gaming oc',
+			model: 'tuf oc',
 			series: '3090',
 			url:
 				'https://www.canadacomputers.com/product_info.php?cPath=43_557_559&item_id=181413&language=en'
@@ -320,13 +341,6 @@ export const CanadaComputers: Store = {
 			series: '3090',
 			url:
 				'https://www.canadacomputers.com/product_info.php?cPath=43_557_559&item_id=181350&language=en'
-		},
-		{
-			brand: 'asus',
-			model: 'gaming',
-			series: '3090',
-			url:
-				'https://www.canadacomputers.com/product_info.php?cPath=43_557_559&item_id=181414&language=en'
 		},
 		{
 			brand: 'msi',
@@ -357,6 +371,20 @@ export const CanadaComputers: Store = {
 				'https://www.canadacomputers.com/product_info.php?cPath=43_557_559&item_id=181352&language=en'
 		},
 		{
+			brand: 'gigabyte',
+			model: 'aorus master',
+			series: '3090',
+			url:
+				'https://www.canadacomputers.com/product_info.php?cPath=43_557_559&item_id=183097&language=en'
+		},
+		{
+			brand: 'gigabyte',
+			model: 'vision oc',
+			series: '3090',
+			url:
+				'https://www.canadacomputers.com/product_info.php?cPath=43_557_559&item_id=184164&language=en'
+		},
+		{
 			brand: 'msi',
 			model: 'gaming x trio',
 			series: '3060ti',
@@ -365,7 +393,7 @@ export const CanadaComputers: Store = {
 		},
 		{
 			brand: 'asus',
-			model: 'tuf',
+			model: 'tuf oc',
 			series: '3060ti',
 			url:
 				'https://www.canadacomputers.com/product_info.php?cPath=43_557_559&item_id=184759&language=en'
@@ -379,7 +407,7 @@ export const CanadaComputers: Store = {
 		},
 		{
 			brand: 'asus',
-			model: 'dual',
+			model: 'dual oc',
 			series: '3060ti',
 			url:
 				'https://www.canadacomputers.com/product_info.php?cPath=43_557_559&item_id=184760&language=en'
@@ -400,7 +428,7 @@ export const CanadaComputers: Store = {
 		},
 		{
 			brand: 'asus',
-			model: 'strix',
+			model: 'strix oc',
 			series: '3060ti',
 			url:
 				'https://www.canadacomputers.com/product_info.php?cPath=43_557_559&item_id=184431&language=en'
@@ -442,7 +470,7 @@ export const CanadaComputers: Store = {
 		},
 		{
 			brand: 'gigabyte',
-			model: 'aorus',
+			model: 'aorus master',
 			series: '3060ti',
 			url:
 				'https://www.canadacomputers.com/product_info.php?cPath=43_557_559&item_id=185405&language=en'
@@ -453,6 +481,83 @@ export const CanadaComputers: Store = {
 			series: '3060ti',
 			url:
 				'https://www.canadacomputers.com/product_info.php?cPath=43_557_559&item_id=185168&language=en'
+		},
+		{
+			brand: 'msi',
+			model: 'gaming x trio',
+			series: 'rx6800',
+			url:
+				'https://www.canadacomputers.com/product_info.php?cPath=43_557_558&item_id=186527&language=en'
+		},
+		{
+			brand: 'sapphire',
+			model: 'nitro+',
+			series: 'rx6800',
+			url:
+				'https://www.canadacomputers.com/product_info.php?cPath=43_557_558&item_id=185755&language=en'
+		},
+		{
+			brand: 'asus',
+			model: 'strix oc',
+			series: 'rx6800',
+			url:
+				'https://www.canadacomputers.com/product_info.php?cPath=43_557_558&item_id=185459&language=en'
+		},
+		{
+			brand: 'asus',
+			model: 'tuf oc',
+			series: 'rx6800',
+			url:
+				'https://www.canadacomputers.com/product_info.php?cPath=43_557_558&item_id=185460&language=en'
+		},
+		{
+			brand: 'msi',
+			model: 'gaming x trio',
+			series: 'rx6800xt',
+			url:
+				'https://www.canadacomputers.com/product_info.php?cPath=43_557_558&item_id=186526&language=en'
+		},
+		{
+			brand: 'sapphire',
+			model: 'nitro+',
+			series: 'rx6800xt',
+			url:
+				'https://www.canadacomputers.com/product_info.php?cPath=43_557_558&item_id=185754&language=en'
+		},
+		{
+			brand: 'sapphire',
+			model: 'nitro+ se',
+			series: 'rx6800xt',
+			url:
+				'https://www.canadacomputers.com/product_info.php?cPath=43_557_558&item_id=185753&language=en'
+		},
+		{
+			brand: 'gigabyte',
+			model: 'gaming oc',
+			series: 'rx6800xt',
+			url:
+				'https://www.canadacomputers.com/product_info.php?cPath=43_557_558&item_id=185891&language=en'
+		},
+		{
+			brand: 'asus',
+			model: 'strix lc',
+			series: 'rx6800xt',
+			url:
+				'https://www.canadacomputers.com/product_info.php?cPath=43_557_558&item_id=185458&language=en'
+		},
+		{
+			brand: 'asus',
+			model: 'tuf oc',
+			series: 'rx6900xt',
+			url:
+				'https://www.canadacomputers.com/product_info.php?cPath=43_557_558&item_id=186610&language=en'
+		},
+		{
+			brand: 'sapphire',
+			model: 'nitro+',
+			series: 'rx6900xt',
+			url:
+				'https://www.canadacomputers.com/product_info.php?cPath=43_557_558&item_id=186614&language=en'
 		},
 		{
 			brand: 'amd',
@@ -481,6 +586,13 @@ export const CanadaComputers: Store = {
 			series: 'ryzen5950',
 			url:
 				'https://www.canadacomputers.com/product_info.php?cPath=4_64&item_id=183427&language=en'
+		},
+		{
+			brand: 'microsoft',
+			model: 'xbox series x',
+			series: 'xboxsx',
+			url:
+				'https://www.canadacomputers.com/product_info.php?cPath=13_1860_1862&item_id=184244&language=en'
 		}
 	],
 	name: 'canadacomputers',

--- a/src/store/model/memoryexpress.ts
+++ b/src/store/model/memoryexpress.ts
@@ -304,12 +304,12 @@ export const MemoryExpress: Store = {
 			url: 'https://www.memoryexpress.com/Products/MX00114449'
 		},
 		// TODO: uncomment this when #1555 is merged
-		/*{
+		/* {
 			brand: 'asus',
 			model: 'ekwb',
 			series: '3090',
 			url: 'https://www.memoryexpress.com/Products/MX00115135'
-		},*/
+		}, */
 		{
 			brand: 'asus',
 			model: 'strix oc',

--- a/src/store/model/memoryexpress.ts
+++ b/src/store/model/memoryexpress.ts
@@ -35,25 +35,25 @@ export const MemoryExpress: Store = {
 		},
 		{
 			brand: 'asus',
-			model: 'dual',
+			model: 'dual oc',
 			series: '3060ti',
 			url: 'https://www.memoryexpress.com/Products/MX00114818'
 		},
 		{
 			brand: 'asus',
-			model: 'strix',
+			model: 'strix oc',
 			series: '3060ti',
 			url: 'https://www.memoryexpress.com/Products/MX00114786'
 		},
 		{
 			brand: 'asus',
-			model: 'tuf',
+			model: 'tuf oc',
 			series: '3060ti',
 			url: 'https://www.memoryexpress.com/Products/MX00114819'
 		},
 		{
 			brand: 'gigabyte',
-			model: 'aorus',
+			model: 'aorus master',
 			series: '3060ti',
 			url: 'https://www.memoryexpress.com/Products/MX00114923'
 		},
@@ -124,12 +124,6 @@ export const MemoryExpress: Store = {
 			url: 'https://www.memoryexpress.com/Products/MX00114455'
 		},
 		{
-			brand: 'xfx',
-			model: 'amd reference',
-			series: 'rx6800xt',
-			url: 'https://www.memoryexpress.com/Products/MX00114996'
-		},
-		{
 			brand: 'gigabyte',
 			model: 'eagle',
 			series: '3080',
@@ -161,7 +155,7 @@ export const MemoryExpress: Store = {
 		},
 		{
 			brand: 'asus',
-			model: 'gaming oc',
+			model: 'tuf oc',
 			series: '3080',
 			url: 'https://www.memoryexpress.com/Products/MX00114003'
 		},
@@ -214,22 +208,257 @@ export const MemoryExpress: Store = {
 			url: 'https://www.memoryexpress.com/Products/MX00114404'
 		},
 		{
+			brand: 'asus',
+			model: 'strix oc',
+			series: '3080',
+			url: 'https://www.memoryexpress.com/Products/MX00115134'
+		},
+		{
+			brand: 'msi',
+			model: 'suprim x',
+			series: '3080',
+			url: 'https://www.memoryexpress.com/Products/MX00114907'
+		},
+		{
+			brand: 'asus',
+			model: 'dual oc',
+			series: '3070',
+			url: 'https://www.memoryexpress.com/Products/MX00114566'
+		},
+		{
+			brand: 'asus',
+			model: 'ko',
+			series: '3070',
+			url: 'https://www.memoryexpress.com/Products/MX00114785'
+		},
+		{
+			brand: 'asus',
+			model: 'strix oc',
+			series: '3070',
+			url: 'https://www.memoryexpress.com/Products/MX00114560'
+		},
+		{
+			brand: 'asus',
+			model: 'tuf oc',
+			series: '3070',
+			url: 'https://www.memoryexpress.com/Products/MX00114567'
+		},
+		{
+			brand: 'evga',
+			model: 'ftw3 ultra',
+			series: '3070',
+			url: 'https://www.memoryexpress.com/Products/MX00114607'
+		},
+		{
+			brand: 'evga',
+			model: 'xc3 black',
+			series: '3070',
+			url: 'https://www.memoryexpress.com/Products/MX00114605'
+		},
+		{
+			brand: 'evga',
+			model: 'xc3 ultra',
+			series: '3070',
+			url: 'https://www.memoryexpress.com/Products/MX00114606'
+		},
+		{
+			brand: 'gigabyte',
+			model: 'aorus master',
+			series: '3070',
+			url: 'https://www.memoryexpress.com/Products/MX00114688'
+		},
+		{
+			brand: 'gigabyte',
+			model: 'eagle oc',
+			series: '3070',
+			url: 'https://www.memoryexpress.com/Products/MX00114407'
+		},
+		{
+			brand: 'gigabyte',
+			model: 'gaming oc',
+			series: '3070',
+			url: 'https://www.memoryexpress.com/Products/MX00114405'
+		},
+		{
+			brand: 'gigabyte',
+			model: 'vision oc',
+			series: '3070',
+			url: 'https://www.memoryexpress.com/Products/MX00114689'
+		},
+		{
+			brand: 'msi',
+			model: 'gaming x trio',
+			series: '3070',
+			url: 'https://www.memoryexpress.com/Products/MX00114447'
+		},
+		{
+			brand: 'msi',
+			model: 'ventus 2x oc',
+			series: '3070',
+			url: 'https://www.memoryexpress.com/Products/MX00114448'
+		},
+		{
+			brand: 'msi',
+			model: 'ventus 3x oc',
+			series: '3070',
+			url: 'https://www.memoryexpress.com/Products/MX00114449'
+		},
+		// TODO: uncomment this when #1555 is merged
+		/*{
+			brand: 'asus',
+			model: 'ekwb',
+			series: '3090',
+			url: 'https://www.memoryexpress.com/Products/MX00115135'
+		},*/
+		{
+			brand: 'asus',
+			model: 'strix oc',
+			series: '3090',
+			url: 'https://www.memoryexpress.com/Products/MX00114093'
+		},
+		{
+			brand: 'asus',
+			model: 'strix oc',
+			series: '3090',
+			url: 'https://www.memoryexpress.com/Products/MX00115133'
+		},
+		{
+			brand: 'asus',
+			model: 'tuf oc',
+			series: '3090',
+			url: 'https://www.memoryexpress.com/Products/MX00114001'
+		},
+		{
+			brand: 'evga',
+			model: 'ftw3',
+			series: '3090',
+			url: 'https://www.memoryexpress.com/Products/MX00114315'
+		},
+		{
+			brand: 'evga',
+			model: 'ftw3 ultra',
+			series: '3090',
+			url: 'https://www.memoryexpress.com/Products/MX00114155'
+		},
+		{
+			brand: 'evga',
+			model: 'xc3',
+			series: '3090',
+			url: 'https://www.memoryexpress.com/Products/MX00114153'
+		},
+		{
+			brand: 'evga',
+			model: 'xc3 ultra',
+			series: '3090',
+			url: 'https://www.memoryexpress.com/Products/MX00114154'
+		},
+		{
+			brand: 'gigabyte',
+			model: 'aorus master',
+			series: '3090',
+			url: 'https://www.memoryexpress.com/Products/MX00114401'
+		},
+		{
+			brand: 'gigabyte',
+			model: 'aorus xtreme',
+			series: '3090',
+			url: 'https://www.memoryexpress.com/Products/MX00114397'
+		},
+		{
+			brand: 'gigabyte',
+			model: 'eagle',
+			series: '3090',
+			url: 'https://www.memoryexpress.com/Products/MX00114686'
+		},
+		{
+			brand: 'gigabyte',
+			model: 'eagle oc',
+			series: '3090',
+			url: 'https://www.memoryexpress.com/Products/MX00113953'
+		},
+		{
+			brand: 'gigabyte',
+			model: 'gaming oc',
+			series: '3090',
+			url: 'https://www.memoryexpress.com/Products/MX00113952'
+		},
+		{
+			brand: 'gigabyte',
+			model: 'vision oc',
+			series: '3090',
+			url: 'https://www.memoryexpress.com/Products/MX00114685'
+		},
+		{
+			brand: 'msi',
+			model: 'gaming x trio',
+			series: '3090',
+			url: 'https://www.memoryexpress.com/Products/MX00113959'
+		},
+		{
+			brand: 'msi',
+			model: 'ventus 3x oc',
+			series: '3090',
+			url: 'https://www.memoryexpress.com/Products/MX00113958'
+		},
+		{
+			brand: 'msi',
+			model: 'suprim x',
+			series: '3090',
+			url: 'https://www.memoryexpress.com/Products/MX00114908'
+		},
+		{
 			brand: 'sapphire',
 			model: 'pulse',
 			series: 'rx6800xt',
-			url: 'https://www.memoryexpress.com/Products/MX00114404'
+			url: 'https://www.memoryexpress.com/Products/MX00115124'
 		},
 		{
 			brand: 'gigabyte',
 			model: 'gaming oc',
 			series: 'rx6800xt',
-			url: 'https://www.memoryexpress.com/Products/MX00114404'
+			url: 'https://www.memoryexpress.com/Products/MX00115048'
 		},
 		{
 			brand: 'xfx',
 			model: 'merc',
 			series: 'rx6800xt',
-			url: 'https://www.memoryexpress.com/Products/MX00114404'
+			url: 'https://www.memoryexpress.com/Products/MX00114996'
+		},
+		{
+			brand: 'asus',
+			model: 'strix oc',
+			series: 'rx6800',
+			url: 'https://www.memoryexpress.com/Products/MX00114938'
+		},
+		{
+			brand: 'asus',
+			model: 'tuf oc',
+			series: 'rx6800',
+			url: 'https://www.memoryexpress.com/Products/MX00114937'
+		},
+		{
+			brand: 'gigabyte',
+			model: 'gaming oc',
+			series: 'rx6800',
+			url: 'https://www.memoryexpress.com/Products/MX00115049'
+		},
+		{
+			brand: 'sapphire',
+			model: 'nitro+',
+			series: 'rx6800',
+			url: 'https://www.memoryexpress.com/Products/MX00115123'
+		},
+		{
+			brand: 'xfx',
+			model: 'merc',
+			series: 'rx6800',
+			url: 'https://www.memoryexpress.com/Products/MX00114997'
+		},
+		{
+			brand: 'xfx',
+			model: 'merc',
+			series: 'rx6900xt',
+			url: 'https://www.memoryexpress.com/Products/MX00115051'
 		}
 	],
 	name: 'memoryexpress',

--- a/src/store/model/newegg-ca.ts
+++ b/src/store/model/newegg-ca.ts
@@ -100,6 +100,13 @@ export const NeweggCa: Store = {
 				'https://www.newegg.ca/msi-geforce-rtx-3080-rtx-3080-gaming-x-trio-10g/p/N82E16814137597'
 		},
 		{
+			brand: 'msi',
+			model: 'suprim x',
+			series: '3080',
+			url:
+				'https://www.newegg.ca/msi-geforce-rtx-3080-rtx3080-suprim-x-10g/p/N82E16814137609'
+		},
+		{
 			brand: 'gigabyte',
 			itemNumber: '149-32-329',
 			model: 'gaming oc',
@@ -117,11 +124,25 @@ export const NeweggCa: Store = {
 		},
 		{
 			brand: 'gigabyte',
+			model: 'eagle',
+			series: '3080',
+			url:
+				'https://www.newegg.ca/gigabyte-geforce-rtx-3080-gv-n3080eagle-10gd/p/N82E16814932367'
+		},
+		{
+			brand: 'gigabyte',
 			itemNumber: '14-932-336',
 			model: 'aorus master',
 			series: '3080',
 			url:
 				'https://www.newegg.ca/gigabyte-geforce-rtx-3080-gv-n3080aorus-m-10gd/p/N82E16814932336'
+		},
+		{
+			brand: 'gigabyte',
+			model: 'aorus xtreme',
+			series: '3080',
+			url:
+				'https://www.newegg.ca/gigabyte-geforce-rtx-3080-gv-n3080aorus-x-10gd/p/N82E16814932345'
 		},
 		{
 			brand: 'zotac',
@@ -134,7 +155,7 @@ export const NeweggCa: Store = {
 		{
 			brand: 'asus',
 			itemNumber: '14-126-457',
-			model: 'strix',
+			model: 'strix oc',
 			series: '3080',
 			url:
 				'https://www.newegg.ca/asus-geforce-rtx-3080-rog-strix-rtx3080-o10g-gaming/p/N82E16814126457'
@@ -188,12 +209,33 @@ export const NeweggCa: Store = {
 				'https://www.newegg.ca/gigabyte-geforce-rtx-3090-gv-n3090gaming-oc-24gd/p/N82E16814932327'
 		},
 		{
+			brand: 'gigabyte',
+			model: 'aorus master',
+			series: '3090',
+			url:
+				'https://www.newegg.ca/gigabyte-geforce-rtx-3090-gv-n3090aorus-m-24gd/p/N82E16814932341'
+		},
+		{
 			brand: 'msi',
 			itemNumber: '14-137-596',
 			model: 'ventus 3x oc',
 			series: '3090',
 			url:
 				'https://www.newegg.ca/msi-geforce-rtx-3090-rtx-3090-ventus-3x-24g-oc/p/N82E16814137596'
+		},
+		{
+			brand: 'msi',
+			model: 'ventus 3x',
+			series: '3090',
+			url:	
+				'https://www.newegg.ca/msi-geforce-rtx-3090-rtx-3090-ventus-3x-24g/p/N82E16814137599'
+		},
+		{
+			brand: 'msi',
+			model: 'suprim x',
+			series: '3090',
+			url:
+				'https://www.newegg.ca/msi-geforce-rtx-3090-rtx3090-suprim-x-24g/p/N82E16814137610'
 		},
 		{
 			brand: 'zotac',
@@ -206,15 +248,22 @@ export const NeweggCa: Store = {
 		{
 			brand: 'asus',
 			itemNumber: '14-126-454',
-			model: 'tuf',
+			model: 'tuf oc',
 			series: '3090',
 			url:
 				'https://www.newegg.ca/asus-geforce-rtx-3090-tuf-rtx3090-o24g-gaming/p/N82E16814126454'
 		},
 		{
 			brand: 'asus',
+			model: 'tuf',
+			series: '3090',
+			url:
+				'https://www.newegg.ca/asus-geforce-rtx-3090-tuf-rtx3090-24g-gaming/p/N82E16814126455'
+		},
+		{
+			brand: 'asus',
 			itemNumber: '14-126-456',
-			model: 'strix',
+			model: 'strix oc',
 			series: '3090',
 			url:
 				'https://www.newegg.ca/asus-geforce-rtx-3090-rog-strix-rtx3090-o24g-gaming/p/N82E16814126456'
@@ -254,15 +303,22 @@ export const NeweggCa: Store = {
 		{
 			brand: 'msi',
 			itemNumber: '14-137-602',
-			model: 'ventus 2x',
+			model: 'ventus 2x oc',
 			series: '3070',
 			url:
 				'https://www.newegg.ca/msi-geforce-rtx-3070-rtx-3070-ventus-2x-oc/p/N82E16814137602'
 		},
 		{
 			brand: 'msi',
+			model: 'ventus 2x',
+			series: '3070',
+			url:
+				'https://www.newegg.ca/msi-geforce-rtx-3070-rtx-3070-ventus-2x/p/N82E16814137605'
+		},
+		{
+			brand: 'msi',
 			itemNumber: '14-137-601',
-			model: 'ventus 3x',
+			model: 'ventus 3x oc',
 			series: '3070',
 			url:
 				'https://www.newegg.ca/msi-geforce-rtx-3070-rtx-3070-ventus-3x-oc/p/N82E16814137601'
@@ -274,6 +330,13 @@ export const NeweggCa: Store = {
 			series: '3070',
 			url:
 				'https://www.newegg.ca/msi-geforce-rtx-3070-rtx-3070-gaming-x-trio/p/N82E16814137603'
+		},
+		{
+			brand: 'msi',
+			model: 'suprim x',
+			series: '3070',
+			url:
+				'https://www.newegg.ca/msi-geforce-rtx-3070-rtx-3070-suprim-x-8g/p/N82E16814137620'
 		},
 		{
 			brand: 'asus',
@@ -302,10 +365,17 @@ export const NeweggCa: Store = {
 		{
 			brand: 'asus',
 			itemNumber: '14-126-458',
-			model: 'strix',
+			model: 'strix oc',
 			series: '3070',
 			url:
 				'https://www.newegg.ca/asus-geforce-rtx-3070-rog-strix-rtx3070-o8g-gaming/p/N82E16814126458'
+		},
+		{
+			brand: 'asus',
+			model: 'ko',
+			series: '3070',
+			url:
+				'https://www.newegg.ca/asus-geforce-rtx-3070-ko-rtx3070-o8g-gamin/p/N82E16814126466'
 		},
 		{
 			brand: 'zotac',
@@ -374,7 +444,7 @@ export const NeweggCa: Store = {
 		{
 			brand: 'gigabyte',
 			itemNumber: '14-932-359',
-			model: 'aorus',
+			model: 'aorus master',
 			series: '3070',
 			url:
 				'https://www.newegg.ca/gigabyte-geforce-rtx-3070-gv-n3070aorus-m-8gd/p/N82E16814932359'
@@ -422,7 +492,7 @@ export const NeweggCa: Store = {
 		{
 			brand: 'asus',
 			itemNumber: '14-126-471',
-			model: 'tuf',
+			model: 'tuf oc',
 			series: '3060ti',
 			url:
 				'https://www.newegg.ca/asus-geforce-rtx-3060-ti-tuf-rtx3060ti-o8g-gaming/p/N82E16814126471'
@@ -438,7 +508,7 @@ export const NeweggCa: Store = {
 		{
 			brand: 'gigabyte',
 			itemNumber: '14-932-375',
-			model: 'aorus',
+			model: 'aorus master',
 			series: '3060ti',
 			url:
 				'https://www.newegg.ca/gigabyte-geforce-rtx-3060-ti-gv-n306taorus-m-8gd/p/N82E16814932375'
@@ -446,7 +516,7 @@ export const NeweggCa: Store = {
 		{
 			brand: 'asus',
 			itemNumber: '14-126-468',
-			model: 'dual',
+			model: 'dual oc',
 			series: '3060ti',
 			url:
 				'https://www.newegg.ca/asus-geforce-rtx-3060-ti-dual-rtx3060ti-o8g/p/N82E16814126468'
@@ -454,7 +524,7 @@ export const NeweggCa: Store = {
 		{
 			brand: 'asus',
 			itemNumber: '14-126-470',
-			model: 'strix',
+			model: 'strix oc',
 			series: '3060ti',
 			url:
 				'https://www.newegg.ca/asus-geforce-rtx-3060-ti-rog-strix-rtx3060ti-o8g-gaming/p/N82E16814126470'
@@ -476,14 +546,6 @@ export const NeweggCa: Store = {
 				'https://www.newegg.ca/gigabyte-geforce-rtx-3060-ti-gv-n306tgamingoc-pro-8gd/p/N82E16814932376'
 		},
 		{
-			brand: 'zotac',
-			itemNumber: '14-500-507',
-			model: 'gaming',
-			series: '3060ti',
-			url:
-				'https://www.newegg.ca/zotac-geforce-rtx-3060-ti-zt-a30610h-10m/p/N82E16814500507'
-		},
-		{
 			brand: 'evga',
 			itemNumber: '14-487-537',
 			model: 'ftw3 ultra',
@@ -494,7 +556,7 @@ export const NeweggCa: Store = {
 		{
 			brand: 'msi',
 			itemNumber: '14-137-612',
-			model: 'ventus 2x',
+			model: 'ventus 2x oc',
 			series: '3060ti',
 			url:
 				'https://www.newegg.ca/msi-geforce-rtx-3060-ti-rtx-3060-ti-ventus-2x-oc/p/N82E16814137612'
@@ -538,6 +600,14 @@ export const NeweggCa: Store = {
 			series: '3060ti',
 			url:
 				'https://www.newegg.ca/zotac-geforce-rtx-3060-ti-zt-a30610e-10m/p/N82E16814500506'
+		},
+		{
+			brand: 'zotac',
+			itemNumber: '14-500-507',
+			model: 'twin edge oc',
+			series: '3060ti',
+			url:
+				'https://www.newegg.ca/zotac-geforce-rtx-3060-ti-zt-a30610h-10m/p/N82E16814500507'
 		},
 		{
 			brand: 'amd',
@@ -660,7 +730,7 @@ export const NeweggCa: Store = {
 		},
 		{
 			brand: 'asus',
-			model: 'tuf',
+			model: 'tuf oc',
 			series: 'rx6800xt',
 			url:
 				'https://www.newegg.ca/asus-radeon-rx-6800-xt-tuf-rx6800xt-o16g-gaming/p/N82E16814126476'
@@ -674,7 +744,7 @@ export const NeweggCa: Store = {
 		},
 		{
 			brand: 'asus',
-			model: 'strix',
+			model: 'strix oc',
 			series: 'rx6800',
 			url:
 				'https://www.newegg.ca/asus-radeon-rx-6800-rog-strix-rx6800-o16g-gaming/p/N82E16814126477'
@@ -688,14 +758,14 @@ export const NeweggCa: Store = {
 		},
 		{
 			brand: 'sapphire',
-			model: 'nitro+',
+			model: 'nitro+ se',
 			series: 'rx6800xt',
 			url:
 				'https://www.newegg.ca/sapphire-radeon-rx-6800-xt-11304-01-20g/p/N82E16814202390'
 		},
 		{
 			brand: 'asus',
-			model: 'strix',
+			model: 'strix oc',
 			series: 'rx6800xt',
 			url:
 				'https://www.newegg.ca/asus-radeon-rx-6800-xt-rog-strix-lc-rx6800xt-o16g-gaming/p/N82E16814126475'
@@ -716,7 +786,7 @@ export const NeweggCa: Store = {
 		},
 		{
 			brand: 'asus',
-			model: 'tuf',
+			model: 'tuf oc',
 			series: 'rx6800',
 			url:
 				'https://www.newegg.ca/asus-radeon-rx-6800-tuf-rx6800-o16g-gaming/p/N82E16814126478'
@@ -769,6 +839,13 @@ export const NeweggCa: Store = {
 			series: 'rx6900xt',
 			url:
 				'https://www.newegg.ca/powercolor-radeon-rx-6900-xt-axrx-6900xt-16gbd6-m2dhc/p/N82E16814131774'
+		},
+		{
+			brand: 'sapphire',
+			model: 'nitro+',
+			series: 'rx6900xt',
+			url:
+				'https://www.newegg.ca/sapphire-radeon-rx-6900-xt-11308-01-20g/p/N82E16814202395'
 		}
 	],
 	name: 'newegg-ca',

--- a/src/store/model/newegg-ca.ts
+++ b/src/store/model/newegg-ca.ts
@@ -21,11 +21,10 @@ export const NeweggCa: Store = {
 	links: [
 		{
 			brand: 'test:brand',
-			itemNumber: '14-500-495',
 			model: 'test:model',
 			series: 'test:series',
 			url:
-				'https://www.newegg.ca/evga-geforce-rtx-2060-06g-p4-2066-kr/p/N82E16814487488'
+				'https://www.newegg.ca/p/N82E16824475043?Item=N82E16824475043&cm_sp=Homepage_MKPL-_-P3_24-475-043-_-12302020'
 		},
 		{
 			brand: 'asus',
@@ -227,7 +226,7 @@ export const NeweggCa: Store = {
 			brand: 'msi',
 			model: 'ventus 3x',
 			series: '3090',
-			url:	
+			url:
 				'https://www.newegg.ca/msi-geforce-rtx-3090-rtx-3090-ventus-3x-24g/p/N82E16814137599'
 		},
 		{


### PR DESCRIPTION
### Description

Fixes #1513 and fixes #1371 

I noticed multiple different CPUs/GPUs were not present in several different Canadian retailers, I went through the list of them and added the missing cards and removed some dead links (which caused the issue in #1513). While doing so, I noticed many Twin Edge, TUF, Aourus Master and Eagle cards were mis-categorized or were missing the oc suffix.

amazon-ca wasn't updated as a part of this, finding cards is a bit of a mess right now as amazon tends to hide products with no stock in strange ways.

### Testing

I've been running this branch for ~24 hours now and haven't identified any issues. The new cards are being searched and old cards are now searched under the correct category (the issue in #1371)