### PR TITLE
fix(galaxus): update selector

### DIFF
--- a/src/store/model/galaxus.ts
+++ b/src/store/model/galaxus.ts
@@ -8,7 +8,7 @@ export const Galaxus: Store = {
 			text: ['In den Warenkorb']
 		},
 		maxPrice: {
-			container: '.productDetail .ZZ92',
+			container: '.productDetail .Z1ej',
 			euroFormat: true
 		}
 	},


### PR DESCRIPTION
fix: Galaxus again changed the CSS marker for the product_details changed once before 2 days ago

### Description

Galaxus changed once more the CSS marker on the site, last time on 30.12. ( opened pull request #1568 , which as not processed in the meantime and got closed by me ) and beforehand as fixxed around a week ago from knotenjoe in #1469 

### Testing

Script  runs fine with the replaced CSS marker and pulls the correct price from the site again.

