### PR TITLE
chore(store): add missing 3080 cards into Bestbuy-ca: xc3 ultra and zotac trinity oc

### DIFF
--- a/src/store/model/bestbuy-ca.ts
+++ b/src/store/model/bestbuy-ca.ts
@@ -77,6 +77,13 @@ export const BestBuyCa: Store = {
 				'https://www.bestbuy.ca/en-ca/product/evga-geforce-rtx-3080-xc3-ultra-gaming-10gb-gddr6x-video-card/15084753?intl=nosplash'
 		},
 		{
+			brand: 'evga',
+			model: 'xc3 ultra',
+			series: '3080',
+			url:
+				'https://www.bestbuy.ca/en-ca/product/evga-geforce-rtx-3080-xc3-ultra-gaming-10gb-gddr6x-video-card-english/14961449?intl=nosplash'
+		},
+		{
 			brand: 'asus',
 			model: 'tuf',
 			series: '3080',
@@ -96,6 +103,13 @@ export const BestBuyCa: Store = {
 			series: '3090',
 			url:
 				'https://www.bestbuy.ca/en-ca/product/zotac-geforce-rtx-3090-trinity-24gb-gddr6x-video-card/14953250?intl=nosplash'
+		},
+		{
+			brand: 'zotac',
+			model: 'trinity oc',
+			series: '3080',
+			url:
+				'https://www.bestbuy.ca/en-ca/product/zotac-nvidia-geforce-rtx-3080-trinity-oc-10gb-gddr6x-video-card/15000077?intl=nosplash'
 		},
 		{
 			brand: 'asus',


### PR DESCRIPTION


<!-- Please use Conventional Commits to label your title -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/ -->
<!-- Example: feat: allow provided config object to extend other configs  -->

### Description

Adding two new 3080 cards into Bestbuy Canada store file: Zotac Trinity OC and EVGA Ultra Gaming

_This is my first PR on Github ! I hope everything is fine here._

<!-- Fixes #(issue) -->
<!-- Please also include relevant motivation and context. -->

### Testing

<!-- Please describe the tests that you ran to verify your changes. -->
<!-- Provide instructions so we can reproduce. -->
<!-- Please also list any relevant details for your test configuration -->

- Compare the added cards brand with other website (Amazon) to confirm it is the proper brand.

- Script run fine by adding filter on added brands, models.


