### PR TITLE
feat(web): properly set `for` attribute for labels

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -29,7 +29,7 @@
 					}
 					list.appendChild(htmlElement);
 					const htmlLabelElement = document.createElement('label');
-					htmlLabelElement.for = name;
+					htmlLabelElement.setAttribute('for', name);
 					htmlLabelElement.innerText = element;
 					list.appendChild(htmlLabelElement);
 					list.appendChild(document.createElement('br'));


### PR DESCRIPTION
### Description

Fixes an issue where the HTML labels on the web control don't get their `for` attributes set, which means you cannot click on the labels to control the checkboxes. This change uses `setAttribute` to set the `for` attribute correctly.

### Testing

1. Before this PR, click a label in the web control. Notice that it DOESN'T toggle the corresponding checkbox.
2. After this PR, click a label in the web control. Notice that it DOES toggle the corresponding checkbox.
