### PR TITLE
fix(store): Update 30 series links and models for store.asus.com

### DIFF
--- a/src/store/model/asus.ts
+++ b/src/store/model/asus.ts
@@ -20,10 +20,94 @@ export const Asus: Store = {
 		},
 		{
 			brand: 'asus',
-			itemNumber: '202009AM160000001',
+			itemNumber: '202012AM030000004',
+			model: 'tuf oc',
+			series: '3060ti',
+			url: 'https://store.asus.com/us/item/202012AM030000004'
+		},
+		{
+			brand: 'asus',
+			itemNumber: '202012AM030000003',
+			model: 'dual',
+			series: '3060ti',
+			url: 'https://store.asus.com/us/item/202012AM030000003'
+		},
+		{
+			brand: 'asus',
+			itemNumber: '202012AM030000005',
+			model: 'strix oc',
+			series: '3060ti',
+			url: 'https://store.asus.com/us/item/202012AM030000005'
+		},
+		{
+			brand: 'asus',
+			itemNumber: '202012AM030000002',
+			model: 'ko',
+			series: '3060ti',
+			url: 'https://store.asus.com/us/item/202012AM030000002'
+		},
+		{
+			brand: 'asus',
+			itemNumber: '202010AM310000002',
+			model: 'tuf oc',
+			series: '3070',
+			url: 'https://store.asus.com/us/item/202010AM310000002'
+		},
+		{
+			brand: 'asus',
+			itemNumber: '202011AM240000001',
+			model: 'dual',
+			series: '3070',
+			url: 'https://store.asus.com/us/item/202011AM240000001'
+		},
+		{
+			brand: 'asus',
+			itemNumber: '202010AM310000001',
+			model: 'strix',
+			series: '3070',
+			url: 'https://store.asus.com/us/item/202010AM310000001'
+		},
+		{
+			brand: 'asus',
+			itemNumber: '202011AM070000002',
+			model: 'ko oc',
+			series: '3070',
+			url: 'https://store.asus.com/us/item/202011AM070000002'
+		},
+		{
+			brand: 'asus',
+			itemNumber: '202011AM070000003',
+			model: 'dual',
+			series: '3070',
+			url: 'https://store.asus.com/us/item/202011AM070000003'
+		},
+		{
+			brand: 'asus',
+			itemNumber: '202101AM070000001',
+			model: 'strix oc',
+			series: '3070',
+			url: 'https://store.asus.com/us/item/202101AM070000001'
+		},
+		{
+			brand: 'asus',
+			itemNumber: '202012AM160000002',
+			model: 'strix',
+			series: '3080',
+			url: 'https://store.asus.com/us/item/202012AM160000002'
+		},
+		{
+			brand: 'asus',
+			itemNumber: '202011AM190000001',
 			model: 'tuf oc',
 			series: '3080',
-			url: 'https://store.asus.com/us/item/202009AM160000001'
+			url: 'https://store.asus.com/us/item/202011AM190000001'
+		},
+		{
+			brand: 'asus',
+			itemNumber: '202012AM220000002',
+			model: 'strix oc',
+			series: '3080',
+			url: 'https://store.asus.com/us/item/202012AM220000002'
 		},
 		{
 			brand: 'asus',
@@ -34,6 +118,20 @@ export const Asus: Store = {
 		},
 		{
 			brand: 'asus',
+			itemNumber: '202101AM070000002',
+			model: 'ekwb',
+			series: '3080',
+			url: 'https://store.asus.com/us/item/202101AM070000002'
+		},
+		{
+			brand: 'asus',
+			itemNumber: '202011AM190000002',
+			model: 'tuf oc',
+			series: '3090',
+			url: 'https://store.asus.com/us/item/202011AM190000002'
+		},
+		{
+			brand: 'asus',
 			itemNumber: '202009AM150000003',
 			model: 'tuf',
 			series: '3090',
@@ -41,17 +139,17 @@ export const Asus: Store = {
 		},
 		{
 			brand: 'asus',
-			itemNumber: '202009AM150000001',
-			model: 'tuf oc',
+			itemNumber: '202010AM310000004',
+			model: 'strix oc',
 			series: '3090',
-			url: 'https://store.asus.com/us/item/202009AM150000001'
+			url: 'https://store.asus.com/us/item/202010AM310000004'
 		},
 		{
 			brand: 'asus',
-			itemNumber: '202009AM290000002',
+			itemNumber: '202012AM220000001',
 			model: 'strix oc',
-			series: '3080',
-			url: 'https://store.asus.com/us/item/202009AM290000002'
+			series: '3090',
+			url: 'https://store.asus.com/us/item/202012AM220000001'
 		},
 		{
 			brand: 'asus',

--- a/src/store/model/store.ts
+++ b/src/store/model/store.ts
@@ -103,6 +103,7 @@ export type Model =
 	| 'ichill frostbite'
 	| 'igame advanced oc'
 	| 'igame vulcan oc'
+	| 'ko oc'
 	| 'ko'
 	| 'nitro+'
 	| 'nitro+ se'


### PR DESCRIPTION
### Description
Updates the links for 30 series cards on store.asus.com and adds the ASUS 'ko oc' as a Model variant.

### Testing
Testing complete by @wofnull and @kiowadriver in Issue #1637.