### PR TITLE
feat(asus): add outOfStock label

### DIFF
--- a/src/store/model/asus.ts
+++ b/src/store/model/asus.ts
@@ -8,15 +8,19 @@ export const Asus: Store = {
 		inStock: {
 			container: '#item_add_cart',
 			text: ['add to cart']
+		},
+		outOfStock: {
+			container: '#off_sale',
+			text: ['sold out']
 		}
 	},
 	links: [
 		{
 			brand: 'test:brand',
-			itemNumber: '202007AM020000005',
+			itemNumber: '202006AM260000003',
 			model: 'test:model',
 			series: 'test:series',
-			url: 'https://store.asus.com/us/item/202007AM020000005'
+			url: 'https://store.asus.com/us/item/202006AM260000003'
 		},
 		{
 			brand: 'asus',


### PR DESCRIPTION
### Description

Resolves #368

Add `outOfStock` label to help lessen false-positives.

### Testing

```
ＳＴＲＥＥＴＭＥＲＣＨＡＮＴ
3.3.0

[12:09:03 PM] info :: ℹ selected stores: asus
[12:09:03 PM] info :: ℹ selected series: test:series, 3060ti
[12:09:18 PM] info :: 🚀🚨 [asus] [test:brand (test:series)] test:model :: IN STOCK 🚨🚀
https://store.asus.com/us/item/202006AM260000003
[12:09:21 PM] info :: ✖ [asus] [asus (3060ti)] tuf oc :: OUT OF STOCK
```