### PR TITLE
fix(wipoid): added 3090/3080/3070/3060ti/ryzen store items

### DIFF
--- a/docs/reference/filter.md
+++ b/docs/reference/filter.md
@@ -170,7 +170,7 @@ Used with the `SHOW_ONLY_BRANDS` and `SHOW_ONLY_MODELS` variables.
 | Brand | Model |
 |:---:|---|
 | `amd` | `5600x`, `5800x`, `5900x`, `5950x`, `amd reference` |
-| `asus` | `crosshair viii`, `dual`, `dual oc`, `strix`, `strix oc`, `tuf`, `tuf oc` |
+| `asus` | `crosshair viii`, `dual`, `dual oc`, `ekwb`, `strix`, `strix oc`, `strix white`, `tuf`, `tuf oc` |
 | `corsair` | `750 platinum`, `600 platinum` |
 | `colorful` | `igame advanced oc`, `igame vulcan oc` |
 | `evga` | `ftw3`, `ftw3 ultra`, `ftw3 ultra hydro copper`, `xc3`, `xc gaming`, `xc3 black`, `xc3 ultra` |

--- a/docs/reference/filter.md
+++ b/docs/reference/filter.md
@@ -175,7 +175,7 @@ Used with the `SHOW_ONLY_BRANDS` and `SHOW_ONLY_MODELS` variables.
 | `colorful` | `igame advanced oc`, `igame vulcan oc` |
 | `evga` | `ftw3`, `ftw3 ultra`, `ftw3 ultra hydro copper`, `xc3`, `xc gaming`, `xc3 black`, `xc3 ultra` |
 | `gainward` | `phantom gs`, `phoenix`, `phoenix gs`, `phoenix gs oc` |
-| `gigabyte` | `aorus master`, `aorus xtreme`, `aorus xtreme waterforce`, `aorus xtreme waterforce wb`, `eagle`, `eagle oc`, `gaming`, `gaming oc`, `turbo`, `vision`, `vision oc` |
+| `gigabyte` | `aorus master`, `aorus xtreme`, `aorus xtreme waterforce`, `aorus xtreme waterforce wb`, `eagle`, `eagle oc`, `gaming`, `gaming oc`, `gaming oc pro`, `turbo`, `vision`, `vision oc` |
 | `galax` | `sg`, `sg oc` |
 | `inno3d` | `gaming x3`, `ichill x3`, `ichill x4`, `ichill frostbite`, `twin x2 oc` |
 | `kfa2` | `sg`, `sg oc` |

--- a/docs/reference/filter.md
+++ b/docs/reference/filter.md
@@ -184,7 +184,7 @@ Used with the `SHOW_ONLY_BRANDS` and `SHOW_ONLY_MODELS` variables.
 | `msi` | `gaming x trio`, `suprim x`, `ventus 2x oc`, `ventus 3x`, `ventus 3x oc` |
 | `nvidia` | `founders edition` |
 | `palit` | `gamerock oc`, `gaming pro`, `gaming pro oc` |
-| `pny` | `dual fan`, `xlr8 revel`, `xlr8 uprising` |
+| `pny` | `dual fan`, `xlr8 epic x`, `xlr8 revel`, `xlr8 uprising` |
 | `sony` | `ps5 console`, `ps5 digital` |
 | `xfx` | `merc`, `amd reference` |
 | `zotac` | `amp holo`, `amp extreme holo`, `trinity`, `trinity oc`, `twin edge`, `twin edge oc` |

--- a/src/store/model/store.ts
+++ b/src/store/model/store.ts
@@ -125,6 +125,7 @@ export type Model =
 	| 'strix lc'
 	| 'strix oc'
 	| 'strix'
+	| 'strix white'
 	| 'taichi'
 	| 'trinity oc'
 	| 'trinity'

--- a/src/store/model/wipoid.ts
+++ b/src/store/model/wipoid.ts
@@ -158,6 +158,34 @@ export const Wipoid: Store = {
 				'https://www.wipoid.com/pny-geforce-rtx-3080-10gb-xlr8-gaming-epic-x-rgb-10gb-gddr6x.html'
 		},
 		{
+			brand: 'msi',
+			model: 'suprim x',
+			series: '3080',
+			url:
+				'https://www.wipoid.com/msi-geforce-rtx-3080-suprim-x-10gb-gddr6x.html'
+		},
+		{
+			brand: 'zotac',
+			model: 'amp holo',
+			series: '3080',
+			url:
+				'https://www.wipoid.com/zotac-gaming-geforce-rtx-3080-amp-holo-10gb-gddr6x.html'
+		},
+		{
+			brand: 'evga',
+			model: 'ftw3',
+			series: '3080',
+			url:
+				'https://www.wipoid.com/evga-geforce-rtx-3080-ftw3-gaming-10gb-gddr6x.html'
+		},
+		{
+			brand: 'evga',
+			model: 'xc3',
+			series: '3080',
+			url:
+				'https://www.wipoid.com/evga-geforce-rtx-3080-xc3-gaming-10gb-gddr6x.html'
+		},
+		{
 			brand: 'evga',
 			model: 'ftw3 ultra',
 			series: '3090',

--- a/src/store/model/wipoid.ts
+++ b/src/store/model/wipoid.ts
@@ -25,11 +25,123 @@ export const Wipoid: Store = {
 				'https://www.wipoid.com/pny-geforce-rtx-1650-dual-fan-4gb-gddr6.html'
 		},
 		{
+			brand: 'asus',
+			model: 'strix oc',
+			series: '3070',
+			url:
+				'https://www.wipoid.com/asus-rog-strix-geforce-rtx-3070-oc-8gb-gddr6.html'
+		},
+		{
+			brand: 'evga',
+			model: 'ftw3 ultra',
+			series: '3070',
+			url:
+				'https://www.wipoid.com/evga-geforce-rtx-3070-ftw3-ultra-gaming-8gb-gddr6.html'
+		},
+		{
+			brand: 'asus',
+			model: 'tuf oc',
+			series: '3070',
+			url:
+				'https://www.wipoid.com/asus-tuf-gaming-geforce-rtx-3070-oc-edition-8gb-gddr6.html'
+		},
+		{
+			brand: 'gigabyte',
+			model: 'aorus master',
+			series: '3070',
+			url:
+				'https://www.wipoid.com/gigabyte-aorus-geforce-rtx-3070-master-8gb-gddr6.html'
+		},
+		{
+			brand: 'gigabyte',
+			model: 'vision oc',
+			series: '3070',
+			url:
+				'https://www.wipoid.com/gigabyte-aorus-geforce-rtx-3070-master-8gb-gddr6.html'
+		},
+		{
+			brand: 'asus',
+			model: 'strix',
+			series: '3070',
+			url:
+				'https://www.wipoid.com/asus-rog-strix-geforce-rtx-3070-8gb-gddr6.html'
+		},
+		{
+			brand: 'gigabyte',
+			model: 'gaming oc',
+			series: '3070',
+			url:
+				'https://www.wipoid.com/gigabyte-geforce-rtx-3070-gaming-oc-8gb-gddr6.html'
+		},
+		{
+			brand: 'asus',
+			model: 'dual oc',
+			series: '3070',
+			url:
+				'https://www.wipoid.com/asus-dual-geforce-rtx-3070-oc-edition-8gb-gddr6.html'
+		},
+		{
+			brand: 'gigabyte',
+			model: 'eagle oc',
+			series: '3070',
+			url:
+				'https://www.wipoid.com/gigabyte-geforce-rtx-3070-eagle-oc-8gb-gddr6.html'
+		},
+		{
+			brand: 'zotac',
+			model: 'amp holo',
+			series: '3070',
+			url:
+				'https://www.wipoid.com/zotac-gaming-geforce-rtx-3070-amp-holo-8gb-gddr6.html'
+		},
+		{
+			brand: 'asus',
+			model: 'dual',
+			series: '3070',
+			url:
+				'https://www.wipoid.com/asus-dual-geforce-rtx-3070-8gb-gddr6.html'
+		},
+		{
+			brand: 'zotac',
+			model: 'twin edge oc',
+			series: '3070',
+			url:
+				'https://www.wipoid.com/zotac-gaming-geforce-rtx-3070-twin-edge-oc-white-gddr6.html'
+		},
+		{
+			brand: 'pny',
+			model: 'xlr8 epic x',
+			series: '3070',
+			url:
+				'https://www.wipoid.com/pny-geforce-rtx-3070-xlr8-gaming-epic-x-8gb-gddr6x.html'
+		},
+		{
+			brand: 'pny',
+			model: 'dual fan',
+			series: '3070',
+			url:
+				'https://www.wipoid.com/pny-geforce-rtx-3070-dual-fan-8gb-gddr6.html'
+		},
+		{
+			brand: 'zotac',
+			model: 'twin edge oc',
+			series: '3070',
+			url:
+				'https://www.wipoid.com/zotac-gaming-geforce-rtx-3070-twin-edge-oc-8gb-gddr6.html'
+		},
+		{
+			brand: 'zotac',
+			model: 'twin edge',
+			series: '3070',
+			url:
+				'https://www.wipoid.com/zotac-gaming-geforce-rtx-3070-twin-edge-8gb-gddr6.html'
+		},
+		{
 			brand: 'gigabyte',
 			model: 'eagle oc',
 			series: '3080',
 			url:
-				'https://www.wipoid.com/gigabyte-geforce-rtx-3080-eagle-oc-10gb-gddr6x.html'
+				'https://www.wipoid.com/gigabyte-geforce-rtx-3070-vision-oc-8gb-gddr6.html'
 		},
 		{
 			brand: 'msi',

--- a/src/store/model/wipoid.ts
+++ b/src/store/model/wipoid.ts
@@ -158,6 +158,97 @@ export const Wipoid: Store = {
 				'https://www.wipoid.com/pny-geforce-rtx-3080-10gb-xlr8-gaming-epic-x-rgb-10gb-gddr6x.html'
 		},
 		{
+			brand: 'evga',
+			model: 'ftw3 ultra',
+			series: '3090',
+			url:
+				'https://www.wipoid.com/evga-geforce-rtx-3090-ftw3-ultra-gaming-24gb-gddr6x.html'
+		},
+		{
+			brand: 'asus',
+			model: 'ekwb',
+			series: '3090',
+			url:
+				'https://www.wipoid.com/asus-ekwb-geforce-rtx-3090-24gb-gddr6x.html'
+		},
+		{
+			brand: 'asus',
+			model: 'strix white',
+			series: '3090',
+			url:
+				'https://www.wipoid.com/asus-rog-strix-geforce-rtx-3090-oc-edition-white-24gb-gddr6x.html'
+		},
+		{
+			brand: 'asus',
+			model: 'tuf oc',
+			series: '3090',
+			url:
+				'https://www.wipoid.com/asus-tuf-gaming-geforce-rtx-3090-oc-edition-24gb-gddr6x.html'
+		},
+		{
+			brand: 'asus',
+			model: 'strix oc',
+			series: '3090',
+			url:
+				'https://www.wipoid.com/asus-rog-strix-geforce-rtx-3090-oc-edition-24gb-gddr6x.html'
+		},
+		{
+			brand: 'asus',
+			model: 'strix',
+			series: '3090',
+			url:
+				'https://www.wipoid.com/asus-rog-strix-geforce-rtx-3090-24gb-gddr6x.html'
+		},
+		{
+			brand: 'gigabyte',
+			model: 'gaming oc',
+			series: '3090',
+			url:
+				'https://www.wipoid.com/gigabyte-geforce-rtx-3090-oc-24gb-gddr6x.html'
+		},
+		{
+			brand: 'msi',
+			model: 'gaming x trio',
+			series: '3090',
+			url:
+				'https://www.wipoid.com/msi-geforce-rtx-3090-gaming-x-trio-24gb-gddr6x.html'
+		},
+		{
+			brand: 'gigabyte',
+			model: 'eagle oc',
+			series: '3090',
+			url:
+				'https://www.wipoid.com/gigabyte-geforce-rtx-3090-eagle-oc-24gb-gddr6x.html'
+		},
+		{
+			brand: 'asus',
+			model: 'tuf',
+			series: '3090',
+			url:
+				'https://www.wipoid.com/asus-tuf-gaming-geforce-rtx-3090-24gb-gddr6x.html'
+		},
+		{
+			brand: 'zotac',
+			model: 'trinity',
+			series: '3090',
+			url:
+				'https://www.wipoid.com/zotac-gaming-geforce-rtx-3090-trinity-24gb-gddr6x.html'
+		},
+		{
+			brand: 'msi',
+			model: 'ventus 3x',
+			series: '3090',
+			url:
+				'https://www.wipoid.com/msi-geforce-rtx-3090-ventus-3x-24gb-gddr6x.html'
+		},
+		{
+			brand: 'evga',
+			model: 'xc3 ultra',
+			series: '3090',
+			url:
+				'https://www.wipoid.com/evga-geforce-rtx-3090-xc3-ultra-gaming-24gb-gddr6x.html'
+		},
+		{
 			brand: 'amd',
 			model: '5600x',
 			series: 'ryzen5600',

--- a/src/store/model/wipoid.ts
+++ b/src/store/model/wipoid.ts
@@ -26,6 +26,104 @@ export const Wipoid: Store = {
 		},
 		{
 			brand: 'asus',
+			model: 'tuf',
+			series: '3060ti',
+			url:
+				'https://www.wipoid.com/asus-tuf-gaming-geforce-rtx-3060-ti-8gb-gddr6.html'
+		},
+		{
+			brand: 'asus',
+			model: 'strix oc',
+			series: '3060ti',
+			url:
+				'https://www.wipoid.com/asus-rog-strix-geforce-rtx-3060-ti-oc-8gb-gddr6.html'
+		},
+		{
+			brand: 'gigabyte',
+			model: 'aorus master',
+			series: '3060ti',
+			url:
+				'https://www.wipoid.com/gigabyte-aorus-geforce-rtx-3060-ti-master-8gb-gddr6.html'
+		},
+		{
+			brand: 'asus',
+			model: 'tuf oc',
+			series: '3060ti',
+			url:
+				'https://www.wipoid.com/asus-tuf-gaming-geforce-rtx-3060-ti-oc-edition-8gb-gddr6.html'
+		},
+		{
+			brand: 'msi',
+			model: 'gaming x trio',
+			series: '3060ti',
+			url:
+				'https://www.wipoid.com/msi-geforce-rtx-3060-ti-gaming-x-trio-8gb-gddr6.html'
+		},
+		{
+			brand: 'asus',
+			model: 'dual oc',
+			series: '3060ti',
+			url:
+				'https://www.wipoid.com/asus-dual-geforce-rtx-3060-ti-oc-edition-8gb-gddr6.html'
+		},
+		{
+			brand: 'gigabyte',
+			model: 'gaming oc',
+			series: '3060ti',
+			url:
+				'https://www.wipoid.com/gigabyte-geforce-rtx-3060-ti-gaming-oc-8gb-gddr6.html'
+		},
+		{
+			brand: 'gigabyte',
+			model: 'gaming oc pro',
+			series: '3060ti',
+			url:
+				'https://www.wipoid.com/gigabyte-geforce-rtx-3060-ti-gaming-pro-oc-8gb-gddr6.html'
+		},
+		{
+			brand: 'zotac',
+			model: 'twin edge oc',
+			series: '3060ti',
+			url:
+				'https://www.wipoid.com/zotac-gaming-geforce-rtx-3060-ti-twin-edge-oc-8gb-gddr6.html'
+		},
+		{
+			brand: 'palit',
+			model: 'gaming pro',
+			series: '3060ti',
+			url:
+				'https://www.wipoid.com/palit-geforce-rtx-3060-ti-gaming-pro-8gb-gddr6.html'
+		},
+		{
+			brand: 'zotac',
+			model: 'twin edge',
+			series: '3060ti',
+			url:
+				'https://www.wipoid.com/zotac-gaming-geforce-rtx-3060-ti-twin-edge-8gb-gddr6.html'
+		},
+		{
+			brand: 'gigabyte',
+			model: 'eagle',
+			series: '3060ti',
+			url:
+				'https://www.wipoid.com/gigabyte-geforce-rtx-3060-ti-eagle-8gb-gddr6.html'
+		},
+		{
+			brand: 'msi',
+			model: 'ventus 2x oc',
+			series: '3060ti',
+			url:
+				'https://www.wipoid.com/msi-geforce-rtx-3060-ti-ventus-2x-oc-8gb-gddr6.html'
+		},
+		{
+			brand: 'palit',
+			model: 'dual',
+			series: '3060ti',
+			url:
+				'https://www.wipoid.com/palit-geforce-rtx-3060-ti-dual-8gb-gddr6.html'
+		},
+		{
+			brand: 'asus',
 			model: 'strix oc',
 			series: '3070',
 			url:

--- a/src/store/model/wipoid.ts
+++ b/src/store/model/wipoid.ts
@@ -168,6 +168,18 @@ export const Wipoid: Store = {
 			model: '5800x',
 			series: 'ryzen5800',
 			url: 'https://www.wipoid.com/amd-ryzen-7-5800x-3-8ghz.html'
+		},
+		{
+			brand: 'amd',
+			model: '5900x',
+			series: 'ryzen5900',
+			url: 'https://www.wipoid.com/amd-ryzen-9-5900x-3-7ghz.html'
+		},
+		{
+			brand: 'amd',
+			model: '5950x',
+			series: 'ryzen5950',
+			url: 'https://www.wipoid.com/amd-ryzen-9-5950x-3-4ghz.html'
 		}
 	],
 	name: 'wipoid'


### PR DESCRIPTION
### Description

Partly Fixes #1676 for wipoid stock not to be up to date at all. 

Updated Store contents for wipoid:
- Ryzen 5950 / 5900 added
- Added all currently listed 3090 cards not in config
- Added all currently listed 3080 cards not in config
- Added all currently listed 3070 cards not in config ( there were none in the config )
- Added all currently listed 3060ti cards not in config ( there were none in the config )
- update store.ts for additional card types currently missing
- Updated filter.md to fit missing card combinations to documentation 

### Testing
-> Ryzen was tested successfully
![image](https://user-images.githubusercontent.com/449003/104569871-87771480-5651-11eb-9ae2-267b261c6000.png)

-> 3090 was tested successfully
![image](https://user-images.githubusercontent.com/449003/104569962-a37ab600-5651-11eb-8701-ce6a22462f22.png)

-> 3080 was tested successfully
![image](https://user-images.githubusercontent.com/449003/104570083-c5743880-5651-11eb-8c5f-f3b37a13afa9.png)

-> 3070 was tested successfully
![image](https://user-images.githubusercontent.com/449003/104570547-606d1280-5652-11eb-9e2c-1274eeaf5918.png)

-> 3060ti was tested successfully
![image](https://user-images.githubusercontent.com/449003/104570582-6d8a0180-5652-11eb-92d1-71efc1417889.png)
