### PR TITLE
fix(computeruniverse): false positives

### DIFF
--- a/src/store/model/computeruniverse.ts
+++ b/src/store/model/computeruniverse.ts
@@ -17,7 +17,10 @@ export const Computeruniverse: Store = {
 		},
 		outOfStock: {
 			container: '.availability',
-			text: ['nicht verfügbar']
+			text: [
+				'nicht verfügbar',
+				'liefertermin hat erhebliche schwankungen'
+			]
 		}
 	},
 	links: [


### PR DESCRIPTION
### Description

Computeruniverse started listing most of the items "in Stock", basicly they added for 30 series cards another out of stock label.

added it to the out of stock list. 

### Testing

done and verified, items show now properly out of stock.
 