### PR TITLE
fix(acompc): false positives

### DIFF
--- a/src/store/model/acompc.ts
+++ b/src/store/model/acompc.ts
@@ -13,7 +13,7 @@ export const AComPC: Store = {
 		},
 		outOfStock: [
 			{
-				container: '.stockStatus',
+				container: '.filial_stock',
 				text: ['nicht lieferbar']
 			}
 		]


### PR DESCRIPTION
### Description

AcomPC had showing every card as in Stock for the last few days, after checking I found that the out Of Stock text was now under the same selector as the in Stock one, but with another text.

Updated this to the correct selector

### Testing

Tested after changing out of stock is now working again as it should.
