### PR TITLE
fix(newegg): false positives (all stores)

### DIFF
--- a/src/store/model/newegg-ca.ts
+++ b/src/store/model/newegg-ca.ts
@@ -16,7 +16,17 @@ export const NeweggCa: Store = {
 			container:
 				'div#app div.product-price > ul > li.price-current > strong',
 			euroFormat: false
-		}
+		},
+		outOfStock: [
+			{
+				container: '.product-inventory',
+				text: [' out of stock.']
+			},
+			{
+				container: '.product-flag',
+				text: ['out of stock ']
+			},
+		]
 	},
 	links: [
 		{

--- a/src/store/model/newegg-ca.ts
+++ b/src/store/model/newegg-ca.ts
@@ -25,7 +25,7 @@ export const NeweggCa: Store = {
 			{
 				container: '.product-flag',
 				text: ['out of stock ']
-			},
+			}
 		]
 	},
 	links: [

--- a/src/store/model/newegg-sg.ts
+++ b/src/store/model/newegg-sg.ts
@@ -20,7 +20,17 @@ export const NeweggSg: Store = {
 		],
 		maxPrice: {
 			container: '.price-current'
-		}
+		},
+		outOfStock: [
+			{
+				container: '.product-inventory',
+				text: [' out of stock.']
+			},
+			{
+				container: '.product-flag',
+				text: ['out of stock ']
+			},
+		]
 	},
 	links: [
 		{

--- a/src/store/model/newegg-sg.ts
+++ b/src/store/model/newegg-sg.ts
@@ -29,7 +29,7 @@ export const NeweggSg: Store = {
 			{
 				container: '.product-flag',
 				text: ['out of stock ']
-			},
+			}
 		]
 	},
 	links: [

--- a/src/store/model/newegg.ts
+++ b/src/store/model/newegg.ts
@@ -29,7 +29,7 @@ export const Newegg: Store = {
 			{
 				container: '.product-flag',
 				text: ['out of stock ']
-			},
+			}
 		]
 	},
 	links: [

--- a/src/store/model/newegg.ts
+++ b/src/store/model/newegg.ts
@@ -20,7 +20,17 @@ export const Newegg: Store = {
 		],
 		maxPrice: {
 			container: '.price-current'
-		}
+		},
+		outOfStock: [
+			{
+				container: '.product-inventory',
+				text: [' out of stock.']
+			},
+			{
+				container: '.product-flag',
+				text: ['out of stock ']
+			},
+		]
 	},
 	links: [
 		{


### PR DESCRIPTION
### Description
During test run to lockout for new cards on newegg for another fix i do currently prepare, i found that the newegg site ( US / CA / SG ) does give false positives in streetmerchant, showing in Stock items but are in reality out of stock.

Checking against the config file, there was no out of stock check in place and only an instock check, which seemed to hit nothing when cards are not in stock, but still got triggered. Since all 3 sites use the same layout I added ( and tested ) a proper out of stock check.

### Testing
Testing has been done, Items out of stock show now proper out of stock and not the listed price / triggering false positives anymore.