### PR TITLE
feat(store): corsair-uk

### DIFF
--- a/docs/reference/filter.md
+++ b/docs/reference/filter.md
@@ -192,7 +192,7 @@ Used with the `SHOW_ONLY_BRANDS` and `SHOW_ONLY_MODELS` variables.
 |:---:|---|
 | `amd` | `5600x`, `5800x`, `5900x`, `5950x`, `amd reference` |
 | `asus` | `crosshair viii`, `dual`, `dual oc`, `ekwb`, `strix`, `strix oc`, `strix white`, `tuf`, `tuf oc` |
-| `corsair` | `750 platinum`, `600 platinum` |
+| `corsair` | `750 platinum`, `600 platinum`, `600 gold` |
 | `colorful` | `igame advanced oc`, `igame vulcan oc` |
 | `evga` | `ftw3`, `ftw3 black`, `ftw3 ultra`, `ftw3 ultra hybrid`, `ftw3 ultra hydro copper`, `xc3`, `xc black`, `xc gaming`, `xc3 black`, `xc3 ultra`, `xc3 ultra hybrid` |
 | `gainward` | `phantom gs`, `phoenix`, `phoenix gs`, `phoenix gs oc` |

--- a/docs/reference/filter.md
+++ b/docs/reference/filter.md
@@ -84,6 +84,7 @@ Used with the `STORES` variable.
 | Coolblue | NL | `coolblue`|
 | Coolmod | ES | `coolmod`|
 | Corsair | US | `corsair`|
+| Corsair | UK | `corsair-uk`|
 | CPL | AU | `cpl`|
 | Currys | UK | `currys`|
 | Cyberport | DE | `cyberport` |

--- a/src/store/model/corsair-uk.ts
+++ b/src/store/model/corsair-uk.ts
@@ -1,0 +1,46 @@
+import {Store} from './store';
+
+export const CorsairUK: Store = {
+  currency: '£',
+  labels: {
+    outOfStock: {
+      container: '#addToCartForm',
+      text: ['add to cart'],
+    },
+    inStock: {
+      container: '#addToCartForm',
+      text: ['notify me when in stock'],
+    },
+  },
+  links: [
+    {
+      brand: 'test:brand',
+      model: 'test:model',
+      series: 'test:series',
+      url:
+        'https://www.corsair.com/uk/en/Categories/Products/Power-Supply-Units/Power-Supply-Units-Advanced/SF-Series/p/CP-9020181-UK',
+    },
+    {
+      brand: 'corsair',
+      model: '750 platinum',
+      series: 'sf',
+      url:
+        'https://www.corsair.com/uk/en/Categories/Products/Power-Supply-Units/Power-Supply-Units-Advanced/SF-Series/p/CP-9020186-UK',
+    },
+    {
+      brand: 'corsair',
+      model: '600 platinum',
+      series: 'sf',
+      url:
+        'https://www.corsair.com/uk/en/Categories/Products/Power-Supply-Units/Power-Supply-Units-Advanced/SF-Series/p/CP-9020182-UK',
+    },
+    {
+      brand: 'corsair',
+      model: '600 gold',
+      series: 'sf',
+      url:
+        'https://www.corsair.com/uk/en/Categories/Products/Power-Supply-Units/SF-Series%E2%84%A2-80-PLUS-Gold-Power-Supplies/p/CP-9020105-UK',
+    },
+  ],
+  name: 'corsair-uk',
+};

--- a/src/store/model/corsair-uk.ts
+++ b/src/store/model/corsair-uk.ts
@@ -3,11 +3,11 @@ import {Store} from './store';
 export const CorsairUK: Store = {
   currency: '£',
   labels: {
-    outOfStock: {
+    inStock: {
       container: '#addToCartForm',
       text: ['add to cart'],
     },
-    inStock: {
+    outOfStock: {
       container: '#addToCartForm',
       text: ['notify me when in stock'],
     },

--- a/src/store/model/index.ts
+++ b/src/store/model/index.ts
@@ -45,6 +45,7 @@ import {Computeruniverse} from './computeruniverse';
 import {Coolblue} from './coolblue';
 import {Coolmod} from './coolmod';
 import {Corsair} from './corsair';
+import {CorsairUK} from './corsair-uk';
 import {Cpl} from './cpl';
 import {Currys} from './currys';
 import {Cyberport} from './cyberport';
@@ -179,6 +180,7 @@ export const storeList = new Map([
   [Coolblue.name, Coolblue],
   [Coolmod.name, Coolmod],
   [Corsair.name, Corsair],
+  [CorsairUK.name, CorsairUK],
   [Cpl.name, Cpl],
   [Currys.name, Currys],
   [Cyberport.name, Cyberport],

--- a/src/store/model/store.ts
+++ b/src/store/model/store.ts
@@ -65,6 +65,7 @@ export type Model =
   | '5900x'
   | '5950x'
   | '600 platinum'
+  | '600 gold'
   | '750 platinum'
   | 'amd reference'
   | 'amp extreme holo'


### PR DESCRIPTION
### Description

- New UK store variable: `corsair-uk`.
- Checks stock for SF600 Gold, SF600/SF750 Platinum.

### Testing

- Checked against out of stock indicator to confirm it is working.
- Performed robust testing to ensure that it captures the stock correctly.
