### PR TITLE
fix(notebooksbilliger): added 3060ti founders edition

### DIFF
--- a/src/store/model/notebooksbilliger.ts
+++ b/src/store/model/notebooksbilliger.ts
@@ -46,6 +46,13 @@ export const Notebooksbilliger: Store = {
         'https://www.notebooksbilliger.de/gainward+geforce+rtx+2070+super+phoenix+v1+grafikkarte+656238',
     },
     {
+      brand: 'nvidia',
+      model: 'founders edition',
+      series: '3060ti',
+      url:
+        'https://www.notebooksbilliger.de/nvidia+geforce+rtx+3060+ti+founders+edition+695677',
+    },
+    {
       brand: 'inno3d',
       model: 'ichill x3',
       series: '3070',


### PR DESCRIPTION
### Description

Fixes #1729 

Added the missing FE card, checked for the link on Nvidia site for hidden page on notebooksbilliger. The provided mobile link uses the same ID, added the real link to notebooksbilliger.ts.

### Testing

Local test was running fine and gave the awaited card back.