### PR TITLE
fix(discord): ensure first group in list is notified

### DIFF
--- a/src/notification/discord.ts
+++ b/src/notification/discord.ts
@@ -52,7 +52,7 @@ export function sendDiscordMessage(link: Link, store: Store) {
           notifyText = notifyText.concat(notifyGroup);
         }
 
-        if (Object.keys(notifyGroupSeries).indexOf(link.series) !== 0) {
+        if (Object.keys(notifyGroupSeries).indexOf(link.series) !== -1) {
           notifyText = notifyText.concat(notifyGroupSeries[link.series]);
         }
 


### PR DESCRIPTION
<!-- Please use Conventional Commits to label your title -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/ -->
<!-- Example: feat: allow provided config object to extend other configs  -->

### Description

<!-- Fixes #(issue) -->
<!-- Please also include relevant motivation and context. -->

This fix ensures that the `series` of a `link` is found in `notifyGroupSeries`. Before this fix, the first key in `notifyGroupSeries` was excluded. Typically, the first key is `3070`, so Discord notifications wouldn't include an `@mention` for the `3070` role. This fixes that bug.