### PR TITLE
feat: clean up proxy logging with n/N in each lookup

### DIFF
--- a/src/logger.ts
+++ b/src/logger.ts
@@ -241,9 +241,9 @@ function buildSetupString(
 
 function buildProductString(link: Link, store: Store, color?: boolean): string {
   if (color) {
-    if (store.currentProxyIndex && store.proxyList) {
+    if (store.currentProxyIndex !== undefined && store.proxyList) {
       return (
-        chalk.gray(`[${store.currentProxyIndex}/${store.proxyList.length}]`) +
+        chalk.gray(`[${store.currentProxyIndex+1}/${store.proxyList.length}]`) +
         chalk.cyan(` [${store.name}]`) +
         chalk.grey(` [${link.brand} (${link.series})] ${link.model}`)
       );
@@ -255,8 +255,8 @@ function buildProductString(link: Link, store: Store, color?: boolean): string {
     }
   }
 
-  if (store.currentProxyIndex && store.proxyList) {
-    return `[${store.currentProxyIndex}/${store.proxyList.length}] [${store.name}] [${link.brand} (${link.series})] ${link.model}`;
+  if (store.currentProxyIndex !== undefined && store.proxyList) {
+    return `[${store.currentProxyIndex+1}/${store.proxyList.length}] [${store.name}] [${link.brand} (${link.series})] ${link.model}`;
   } else {
     return `[${store.name}] [${link.brand} (${link.series})] ${link.model}`;
   }

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -242,8 +242,9 @@ function buildSetupString(
 function buildProductString(link: Link, store: Store, color?: boolean): string {
   if (color) {
     if (store.currentProxyIndex !== undefined && store.proxyList) {
+      const proxy = `${store.currentProxyIndex + 1}/${store.proxyList.length}`;
       return (
-        chalk.gray(`[${store.currentProxyIndex+1}/${store.proxyList.length}]`) +
+        chalk.gray(`[${proxy}]`) +
         chalk.cyan(` [${store.name}]`) +
         chalk.grey(` [${link.brand} (${link.series})] ${link.model}`)
       );
@@ -251,12 +252,13 @@ function buildProductString(link: Link, store: Store, color?: boolean): string {
       return (
         chalk.cyan(`[${store.name}]`) +
         chalk.grey(` [${link.brand} (${link.series})] ${link.model}`)
-      );      
+      );
     }
   }
 
   if (store.currentProxyIndex !== undefined && store.proxyList) {
-    return `[${store.currentProxyIndex+1}/${store.proxyList.length}] [${store.name}] [${link.brand} (${link.series})] ${link.model}`;
+    const proxy = `${store.currentProxyIndex + 1}/${store.proxyList.length}`;
+    return `[${proxy}] [${store.name}] [${link.brand} (${link.series})] ${link.model}`;
   } else {
     return `[${store.name}] [${link.brand} (${link.series})] ${link.model}`;
   }

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -241,11 +241,23 @@ function buildSetupString(
 
 function buildProductString(link: Link, store: Store, color?: boolean): string {
   if (color) {
-    return (
-      chalk.cyan(`[${store.name}]`) +
-      chalk.grey(` [${link.brand} (${link.series})] ${link.model}`)
-    );
+    if (store.currentProxyIndex && store.proxyList) {
+      return (
+        chalk.gray(`[${store.currentProxyIndex}/${store.proxyList.length}]`) +
+        chalk.cyan(` [${store.name}]`) +
+        chalk.grey(` [${link.brand} (${link.series})] ${link.model}`)
+      );
+    } else {
+      return (
+        chalk.cyan(`[${store.name}]`) +
+        chalk.grey(` [${link.brand} (${link.series})] ${link.model}`)
+      );      
+    }
   }
 
-  return `[${store.name}] [${link.brand} (${link.series})] ${link.model}`;
+  if (store.currentProxyIndex && store.proxyList) {
+    return `[${store.currentProxyIndex}/${store.proxyList.length}] [${store.name}] [${link.brand} (${link.series})] ${link.model}`;
+  } else {
+    return `[${store.name}] [${link.brand} (${link.series})] ${link.model}`;
+  }
 }

--- a/src/store/lookup.ts
+++ b/src/store/lookup.ts
@@ -44,7 +44,7 @@ function nextProxy(store: Store) {
     store.currentProxyIndex = 0;
   }
 
-  logger.info(
+  logger.debug(
     `ℹ [${store.name}] Next proxy index: ${store.currentProxyIndex} / Count: ${store.proxyList.length}`
   );
 

--- a/src/store/lookup.ts
+++ b/src/store/lookup.ts
@@ -37,15 +37,16 @@ function nextProxy(store: Store) {
 
   if (store.currentProxyIndex === undefined) {
     store.currentProxyIndex = 0;
+  } else {
+    store.currentProxyIndex++;
   }
 
-  store.currentProxyIndex++;
   if (store.currentProxyIndex >= store.proxyList.length) {
     store.currentProxyIndex = 0;
   }
 
   logger.debug(
-    `ℹ [${store.name}] Next proxy index: ${store.currentProxyIndex} / Count: ${store.proxyList.length}`
+    `ℹ [${store.name}] Next proxy index: ${store.currentProxyIndex} / Count: ${store.proxyList.length} (${store.proxyList[store.currentProxyIndex]})`
   );
 
   return store.proxyList[store.currentProxyIndex];
@@ -252,9 +253,9 @@ async function lookup(browser: Browser, store: Store) {
     try {
       statusCode = await lookupCard(browser, store, page, link);
     } catch (error: unknown) {
-      if (store.currentProxyIndex && store.proxyList) {
+      if (store.currentProxyIndex !== undefined && store.proxyList) {
         logger.error(
-          `✖ [${store.currentProxyIndex}/${store.proxyList.length}] [${store.name}] ${link.brand} ${link.series} ${link.model} - ${
+          `✖ [${store.currentProxyIndex+1}/${store.proxyList.length}] [${store.name}] ${link.brand} ${link.series} ${link.model} - ${
             (error as Error).message
           }`
         );

--- a/src/store/lookup.ts
+++ b/src/store/lookup.ts
@@ -252,11 +252,19 @@ async function lookup(browser: Browser, store: Store) {
     try {
       statusCode = await lookupCard(browser, store, page, link);
     } catch (error: unknown) {
-      logger.error(
-        `✖ [${store.name}] ${link.brand} ${link.series} ${link.model} - ${
-          (error as Error).message
-        }`
-      );
+      if (store.currentProxyIndex && store.proxyList) {
+        logger.error(
+          `✖ [${store.currentProxyIndex}/${store.proxyList.length}] [${store.name}] ${link.brand} ${link.series} ${link.model} - ${
+            (error as Error).message
+          }`
+        );
+      } else {
+        logger.error(
+          `✖ [${store.name}] ${link.brand} ${link.series} ${link.model} - ${
+            (error as Error).message
+          }`
+        );
+      }
       const client = await page.target().createCDPSession();
       await client.send('Network.clearBrowserCookies');
     }

--- a/src/store/lookup.ts
+++ b/src/store/lookup.ts
@@ -46,7 +46,9 @@ function nextProxy(store: Store) {
   }
 
   logger.debug(
-    `ℹ [${store.name}] Next proxy index: ${store.currentProxyIndex} / Count: ${store.proxyList.length} (${store.proxyList[store.currentProxyIndex]})`
+    `ℹ [${store.name}] Next proxy index: ${store.currentProxyIndex} / Count: ${
+      store.proxyList.length
+    } (${store.proxyList[store.currentProxyIndex]})`
   );
 
   return store.proxyList[store.currentProxyIndex];
@@ -254,10 +256,13 @@ async function lookup(browser: Browser, store: Store) {
       statusCode = await lookupCard(browser, store, page, link);
     } catch (error: unknown) {
       if (store.currentProxyIndex !== undefined && store.proxyList) {
+        const proxy = `${store.currentProxyIndex + 1}/${
+          store.proxyList.length
+        }`;
         logger.error(
-          `✖ [${store.currentProxyIndex+1}/${store.proxyList.length}] [${store.name}] ${link.brand} ${link.series} ${link.model} - ${
-            (error as Error).message
-          }`
+          `✖ [${proxy}] [${store.name}] ${link.brand} ${link.series} ${
+            link.model
+          } - ${(error as Error).message}`
         );
       } else {
         logger.error(


### PR DESCRIPTION
<!-- Please use Conventional Commits to label your title -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/ -->
<!-- Example: feat: allow provided config object to extend other configs  -->

### Description
This is intended to clean up the output so that there aren't a bunch of extraneous lines when using proxies.

Moves the `info` proxy calls to `debug`. I.E:
```
[10:32:52 PM] info :: ℹ [microcenter] Next proxy index: 2 / Count: 3
```
to:
```
[10:32:52 PM] debug :: ℹ [microcenter] Next proxy index: 2 / Count: 3
```

And then when proxies are being used, adds a proxy count before the store name.

Not using proxies:
```
[10:34:34 PM] info :: ✖ [microcenter] [evga (3080)] xc3 ultra :: OUT OF STOCK
[10:34:38 PM] warn :: ✖ [evga] [evga (3060ti)] xc gaming :: STATUS CODE ERROR 403
```
Using proxies:
```
[10:34:34 PM] info :: ✖ [1/3] [microcenter] [evga (3080)] xc3 ultra :: OUT OF STOCK
[10:34:38 PM] warn :: ✖ [1/3] [evga] [evga (3060ti)] xc gaming :: STATUS CODE ERROR 403
```

### Testing

Use a proxy in configurations or in files like `global.proxies`,

