### PR TITLE
fix: mis-placed 3070 Vision OC

### DIFF
--- a/src/store/model/wipoid.ts
+++ b/src/store/model/wipoid.ts
@@ -235,8 +235,8 @@ export const Wipoid: Store = {
     },
     {
       brand: 'gigabyte',
-      model: 'eagle oc',
-      series: '3080',
+      model: 'vision oc',
+      series: '3070',
       url:
         'https://www.wipoid.com/gigabyte-geforce-rtx-3070-vision-oc-8gb-gddr6.html',
     },


### PR DESCRIPTION
<!-- Please use Conventional Commits to label your title -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/ -->
<!-- Example: feat: allow provided config object to extend other configs  -->

### Description

Right now there is a 3070 which is being registered as a 3080 eagle OC, this fixes the series and the model of the graphics card on the wipoid store

![image](https://user-images.githubusercontent.com/29983481/106796467-ac144a00-665b-11eb-8e32-0f483d8982e2.png)
