### PR TITLE
feat(sms): add US Cellular

### DIFF
--- a/docs/reference/notification.md
+++ b/docs/reference/notification.md
@@ -73,6 +73,7 @@ Default provider is Gmail. If you use a different email provider, you must provi
 | Sprint | `sprint`|
 | Telus | `telus`|
 | T-Mobile | `tmobile`|
+| USCC | `uscc`|
 | Verizon | `verizon`|
 | Virgin | `virgin`|
 | Virgin (CA) | `virgin-ca`|

--- a/src/config.ts
+++ b/src/config.ts
@@ -278,6 +278,7 @@ const notifications = {
       ['sprint', 'messaging.sprintpcs.com'],
       ['telus', 'msg.telus.com'],
       ['tmobile', 'tmomail.net'],
+      ['uscc', 'mms.uscc.net'],
       ['verizon', 'vtext.com'],
       ['virgin', 'vmobl.com'],
       ['virgin-ca', 'vmobile.ca'],


### PR DESCRIPTION
### Description
Adds USCC to phone carrier options.
First PR, hopefully I'm doing this right.

### Testing
Forked/modified/cloned locally.  Npm install, nothing broke.  Modified `dotenv` with `PHONE_CARRIER=uscc` and added phone number, npm run start with no errors.  Added `test:brand` and `test:series` via WebUI and got a txt message/email/discord alert shortly after.  There is a `sms.uscc.net` but it doesn't work for this.
