### PR TITLE
fix(wipoid): corrected 3070 / 3080 links

### DIFF
--- a/src/store/model/wipoid.ts
+++ b/src/store/model/wipoid.ts
@@ -155,7 +155,7 @@ export const Wipoid: Store = {
       model: 'vision oc',
       series: '3070',
       url:
-        'https://www.wipoid.com/gigabyte-aorus-geforce-rtx-3070-master-8gb-gddr6.html',
+        'https://www.wipoid.com/gigabyte-geforce-rtx-3070-vision-oc-8gb-gddr6.html',
     },
     {
       brand: 'asus',
@@ -238,7 +238,7 @@ export const Wipoid: Store = {
       model: 'eagle oc',
       series: '3080',
       url:
-        'https://www.wipoid.com/gigabyte-geforce-rtx-3070-vision-oc-8gb-gddr6.html',
+        'https://www.wipoid.com/gigabyte-geforce-rtx-3080-eagle-oc-10gb-gddr6x.html',
     },
     {
       brand: 'msi',


### PR DESCRIPTION
### Description

Fixes issue #1871
Is an error correction to commit be541713a8855f18b5102917751842e514796e00
During addition of the whole 30 series cards from the store, there happened a few copy / paste errors, leading to some false URLs.

### Testing

Links are now corrected and should correspond to the correct product