### PR TITLE
fix(amazon-ca): out of stock check was missing

### DIFF
--- a/src/store/model/amazon-ca.ts
+++ b/src/store/model/amazon-ca.ts
@@ -14,6 +14,10 @@ export const AmazonCa: Store = {
     maxPrice: {
       container: '.a-color-price',
     },
+    outOfStock: {
+      container: '.a-color-price',
+	  text: ['currently unavailable.'],
+	},
   },
   links: [
     {

--- a/src/store/model/amazon-ca.ts
+++ b/src/store/model/amazon-ca.ts
@@ -16,8 +16,8 @@ export const AmazonCa: Store = {
     },
     outOfStock: {
       container: '.a-color-price',
-	  text: ['currently unavailable.'],
-	},
+      text: ['currently unavailable.'],
+    },
   },
   links: [
     {


### PR DESCRIPTION
### Description

Fixes: #1884

During the testrun of #1851 the errors where not triggered. but i think somehow that the missing outofstockcheck in any store will cause problems at some point.

### Testing

Testing done via VPN ( CA ) and directly to find additional issues, after adding out of stock check everything worked fine here.
![image](https://user-images.githubusercontent.com/449003/106967813-0be81f00-6748-11eb-80f6-d495849a7a9e.png)

