### PR TITLE
fix: Notification links should not send cart url when setting is disabled

### DIFF
--- a/src/store/lookup.ts
+++ b/src/store/lookup.ts
@@ -314,7 +314,7 @@ async function lookupCard(
       link.cartUrl && config.store.autoAddToCart ? link.cartUrl : link.url;
     // If autoAddToCart is disabled we should not send link.cartUrl
     if (!config.store.autoAddToCart) {
-      link.cartUrl = undefined
+      link.cartUrl = undefined;
     }
     logger.info(`${Print.inStock(link, store, true)}\n${givenUrl}`);
 

--- a/src/store/lookup.ts
+++ b/src/store/lookup.ts
@@ -312,6 +312,10 @@ async function lookupCard(
   if (await lookupCardInStock(store, page, link)) {
     const givenUrl =
       link.cartUrl && config.store.autoAddToCart ? link.cartUrl : link.url;
+    // If autoAddToCart is disabled we should only send link.url as a notification
+    if (!config.store.autoAddToCart) {
+      link.cartUrl = undefined
+    }
     logger.info(`${Print.inStock(link, store, true)}\n${givenUrl}`);
 
     if (config.browser.open) {

--- a/src/store/lookup.ts
+++ b/src/store/lookup.ts
@@ -312,7 +312,7 @@ async function lookupCard(
   if (await lookupCardInStock(store, page, link)) {
     const givenUrl =
       link.cartUrl && config.store.autoAddToCart ? link.cartUrl : link.url;
-    // If autoAddToCart is disabled we should only send link.url as a notification
+    // If autoAddToCart is disabled we should not send link.cartUrl
     if (!config.store.autoAddToCart) {
       link.cartUrl = undefined
     }


### PR DESCRIPTION
### Description

Fixes #1915
Unsets `link.cartUrl` if `autoAddToCart` is disabled in order to provide the correct URL in notifications.

### Testing

Slack notifications tested, this will possibly cause problems with other notification modules that provide both cart and regular URL though. Would appreciate feedback on whether it is better to have all modules only send either the cart/standard url or for them all to send both, or to leave it as is and apply this fix to individual notification modules.
