### PR TITLE
chore(pccomponentes): add 3090, 3060ti, rx6900xt

### DIFF
--- a/src/store/model/pccomponentes.ts
+++ b/src/store/model/pccomponentes.ts
@@ -29,98 +29,98 @@ export const PCComponentes: Store = {
       model: 'trinity',
       series: '3090',
       url:
-	      'https://www.pccomponentes.com/zotac-gaming-geforce-rtx-3090-trinity-24gb-gddr6x',
+        'https://www.pccomponentes.com/zotac-gaming-geforce-rtx-3090-trinity-24gb-gddr6x',
     },
     {
       brand: 'gigabyte',
       model: 'gaming oc',
       series: '3090',
       url:
-	      'https://www.pccomponentes.com/gigabyte-geforce-rtx-3090-gaming-oc-24g-24gb-gddr6x',
+        'https://www.pccomponentes.com/gigabyte-geforce-rtx-3090-gaming-oc-24g-24gb-gddr6x',
     },
     {
       brand: 'evga',
       model: 'xc3 ultra',
       series: '3090',
       url:
-	      'https://www.pccomponentes.com/evga-geforce-rtx-3090-xc3-ultra-gaming-24gb-gddr6x',
+        'https://www.pccomponentes.com/evga-geforce-rtx-3090-xc3-ultra-gaming-24gb-gddr6x',
     },
     {
       brand: 'asus',
       model: 'tuf oc',
       series: '3090',
       url:
-	      'https://www.pccomponentes.com/asus-tuf-geforce-rtx-3090-gaming-oc-24gb-gddr6x',
+        'https://www.pccomponentes.com/asus-tuf-geforce-rtx-3090-gaming-oc-24gb-gddr6x',
     },
     {
       brand: 'gigabyte',
       model: 'turbo',
       series: '3090',
       url:
-	      'https://www.pccomponentes.com/gigabyte-geforce-rtx-3090-turbo-24gb-gddr6x',
+        'https://www.pccomponentes.com/gigabyte-geforce-rtx-3090-turbo-24gb-gddr6x',
     },
     {
       brand: 'msi',
       model: 'gaming x trio',
       series: '3090',
       url:
-	      'https://www.pccomponentes.com/msi-geforce-rtx-3090-gaming-x-trio-24gb-gddr6x',
+        'https://www.pccomponentes.com/msi-geforce-rtx-3090-gaming-x-trio-24gb-gddr6x',
     },
     {
       brand: 'gigabyte',
       model: 'aorus xtreme',
       series: '3090',
       url:
-	      'https://www.pccomponentes.com/gigabyte-aorus-geforce-rtx-3090-xtreme-24gb-gddrx6',
+        'https://www.pccomponentes.com/gigabyte-aorus-geforce-rtx-3090-xtreme-24gb-gddrx6',
     },
     {
       brand: 'gigabyte',
       model: 'aorus master',
       series: '3090',
       url:
-	      'https://www.pccomponentes.com/gigabyte-aorus-geforce-rtx-3090-master-24gb-gddr6x',
+        'https://www.pccomponentes.com/gigabyte-aorus-geforce-rtx-3090-master-24gb-gddr6x',
     },
     {
       brand: 'asus',
       model: 'strix oc',
       series: '3090',
       url:
-	      'https://www.pccomponentes.com/asus-rog-strix-geforce-rtx-3090-gaming-oc-24gb-gddr6x',
+        'https://www.pccomponentes.com/asus-rog-strix-geforce-rtx-3090-gaming-oc-24gb-gddr6x',
     },
     {
       brand: 'evga',
       model: 'ftw3 ultra hybrid',
       series: '3090',
       url:
-	      'https://www.pccomponentes.com/evga-geforce-rtx-3090-ftw3-ultra-hybrid-gaming-24gb-gddr6x',
+        'https://www.pccomponentes.com/evga-geforce-rtx-3090-ftw3-ultra-hybrid-gaming-24gb-gddr6x',
     },
     {
       brand: 'evga',
       model: 'ftw3 ultra',
       series: '3090',
       url:
-	      'https://www.pccomponentes.com/evga-geforce-rtx-3090-ftw3-ultra-gaming-24gb-gddr6x',
+        'https://www.pccomponentes.com/evga-geforce-rtx-3090-ftw3-ultra-gaming-24gb-gddr6x',
     },
     {
       brand: 'gigabyte',
       model: 'aorus xtreme waterforce wb',
       series: '3090',
       url:
-	      'https://www.pccomponentes.com/gigabyte-aorus-geforce-rtx-3090-xtreme-waterforce-wb-24gb-gddr6x',
+        'https://www.pccomponentes.com/gigabyte-aorus-geforce-rtx-3090-xtreme-waterforce-wb-24gb-gddr6x',
     },
     {
       brand: 'gigabyte',
       model: 'eagle oc',
       series: '3090',
       url:
-	      'https://www.pccomponentes.com/gigabyte-geforce-rtx-3090-eagle-oc-24g-24gb-gddr6x',
+        'https://www.pccomponentes.com/gigabyte-geforce-rtx-3090-eagle-oc-24g-24gb-gddr6x',
     },
     {
       brand: 'msi',
       model: 'ventus 3x oc',
       series: '3090',
       url:
-	      'https://www.pccomponentes.com/msi-geforce-rtx-3090-ventus-3x-oc-24gb-gddr6x',
+        'https://www.pccomponentes.com/msi-geforce-rtx-3090-ventus-3x-oc-24gb-gddr6x',
     },
     {
       brand: 'gigabyte',
@@ -416,112 +416,112 @@ export const PCComponentes: Store = {
       model: 'ventus 2x oc',
       series: '3060ti',
       url:
-	      'https://www.pccomponentes.com/msi-rtx-3060-ti-ventus-2x-oc-8gb-gddr6',
+        'https://www.pccomponentes.com/msi-rtx-3060-ti-ventus-2x-oc-8gb-gddr6',
     },
     {
       brand: 'gigabyte',
       model: 'eagle oc',
       series: '3060ti',
       url:
-	      'https://www.pccomponentes.com/gigabyte-geforce-rtx-3060-ti-eagle-oc-8gb-gddr6',
+        'https://www.pccomponentes.com/gigabyte-geforce-rtx-3060-ti-eagle-oc-8gb-gddr6',
     },
     {
       brand: 'evga',
       model: 'ftw3 ultra',
       series: '3060ti',
       url:
-	      'https://www.pccomponentes.com/evga-geforce-rtx-3060-ti-ftw3-ultra-8gb-gddr6',
+        'https://www.pccomponentes.com/evga-geforce-rtx-3060-ti-ftw3-ultra-8gb-gddr6',
     },
     {
       brand: 'asus',
       model: 'dual oc',
       series: '3060ti',
       url:
-	      'https://www.pccomponentes.com/asus-geforce-rtx-3060ti-dual-o8g-8gb-gddr6',
+        'https://www.pccomponentes.com/asus-geforce-rtx-3060ti-dual-o8g-8gb-gddr6',
     },
     {
       brand: 'gigabyte',
       model: 'gaming oc pro',
       series: '3060ti',
       url:
-	      'https://www.pccomponentes.com/gigabyte-geforce-rtx-3060-ti-gaming-oc-pro-8gb-gddr6',
+        'https://www.pccomponentes.com/gigabyte-geforce-rtx-3060-ti-gaming-oc-pro-8gb-gddr6',
     },
     {
       brand: 'msi',
       model: 'gaming x trio',
       series: '3060ti',
       url:
-	      'https://www.pccomponentes.com/msi-geforce-rtx-3060-ti-gaming-x-8gb-gddr6',
+        'https://www.pccomponentes.com/msi-geforce-rtx-3060-ti-gaming-x-8gb-gddr6',
     },
     {
       brand: 'zotac',
       model: 'twin edge oc',
       series: '3060ti',
       url:
-	      'https://www.pccomponentes.com/zotac-geforce-rtx-3060ti-d6-twin-edge-oc-8gb-gddr6',
+        'https://www.pccomponentes.com/zotac-geforce-rtx-3060ti-d6-twin-edge-oc-8gb-gddr6',
     },
     {
       brand: 'asus',
       model: 'strix oc',
       series: '3060ti',
       url:
-	      'https://www.pccomponentes.com/asus-rog-strix-geforce-rtx-3060ti-o8g-gaming-8gb-gddr6',
+        'https://www.pccomponentes.com/asus-rog-strix-geforce-rtx-3060ti-o8g-gaming-8gb-gddr6',
     },
     {
       brand: 'asus',
       model: 'tuf oc',
       series: '3060ti',
       url:
-	      'https://www.pccomponentes.com/asus-tuf-geforce-rtx-3060ti-o8g-gaming-8gb-gddr6',
+        'https://www.pccomponentes.com/asus-tuf-geforce-rtx-3060ti-o8g-gaming-8gb-gddr6',
     },
     {
       brand: 'msi',
       model: 'gaming x trio',
       series: '3060ti',
       url:
-	      'https://www.pccomponentes.com/msi-rtx-3060-ti-gaming-x-trio-8gb-gddr6',
+        'https://www.pccomponentes.com/msi-rtx-3060-ti-gaming-x-trio-8gb-gddr6',
     },
     {
       brand: 'zotac',
       model: 'twin edge',
       series: '3060ti',
       url:
-	      'https://www.pccomponentes.com/zotac-geforce-rtx-3060-ti-d6-twin-edge-8gb-gddr6',
+        'https://www.pccomponentes.com/zotac-geforce-rtx-3060-ti-d6-twin-edge-8gb-gddr6',
     },
     {
       brand: 'evga',
       model: 'xc gaming',
       series: '3060ti',
       url:
-	      'https://www.pccomponentes.com/evga-geforce-rtx-3060-ti-xc-8gb-gddr6',
+        'https://www.pccomponentes.com/evga-geforce-rtx-3060-ti-xc-8gb-gddr6',
     },
     {
       brand: 'gigabyte',
       model: 'aorus master',
       series: '3060ti',
       url:
-	      'https://www.pccomponentes.com/gigabyte-aorus-geforce-rtx-3060-ti-master-8gb-gddr6',
+        'https://www.pccomponentes.com/gigabyte-aorus-geforce-rtx-3060-ti-master-8gb-gddr6',
     },
     {
       brand: 'pny',
       model: 'xlr8 revel',
       series: '3060ti',
       url:
-	      'https://www.pccomponentes.com/pny-geforce-rtx-3060ti-xlr8-gaming-revel-epic-x-rgb-edition-8gb-gddr6',
+        'https://www.pccomponentes.com/pny-geforce-rtx-3060ti-xlr8-gaming-revel-epic-x-rgb-edition-8gb-gddr6',
     },
     {
       brand: 'gigabyte',
       model: 'gaming oc',
       series: 'rx6900xt',
       url:
-	      'https://www.pccomponentes.com/gigabyte-radeon-rx-6900-xt-gaming-oc-16gb-gddr6',
+        'https://www.pccomponentes.com/gigabyte-radeon-rx-6900-xt-gaming-oc-16gb-gddr6',
     },
     {
       brand: 'asus',
       model: 'tuf oc',
       series: 'rx6900xt',
       url:
-	      'https://www.pccomponentes.com/asus-tuf-amd-radeon-rx-6900xt-oc-16gb-gddr6',
+        'https://www.pccomponentes.com/asus-tuf-amd-radeon-rx-6900xt-oc-16gb-gddr6',
     },
   ],
   name: 'pccomponentes',

--- a/src/store/model/pccomponentes.ts
+++ b/src/store/model/pccomponentes.ts
@@ -25,6 +25,104 @@ export const PCComponentes: Store = {
         'https://www.pccomponentes.com/gigabyte-geforce-gtx-1660-super-oc-6gb-gddr6',
     },
     {
+      brand: 'zotac',
+      model: 'trinity',
+      series: '3090',
+      url:
+	      'https://www.pccomponentes.com/zotac-gaming-geforce-rtx-3090-trinity-24gb-gddr6x',
+    },
+    {
+      brand: 'gigabyte',
+      model: 'gaming oc',
+      series: '3090',
+      url:
+	      'https://www.pccomponentes.com/gigabyte-geforce-rtx-3090-gaming-oc-24g-24gb-gddr6x',
+    },
+    {
+      brand: 'evga',
+      model: 'xc3 ultra',
+      series: '3090',
+      url:
+	      'https://www.pccomponentes.com/evga-geforce-rtx-3090-xc3-ultra-gaming-24gb-gddr6x',
+    },
+    {
+      brand: 'asus',
+      model: 'tuf oc',
+      series: '3090',
+      url:
+	      'https://www.pccomponentes.com/asus-tuf-geforce-rtx-3090-gaming-oc-24gb-gddr6x',
+    },
+    {
+      brand: 'gigabyte',
+      model: 'turbo',
+      series: '3090',
+      url:
+	      'https://www.pccomponentes.com/gigabyte-geforce-rtx-3090-turbo-24gb-gddr6x',
+    },
+    {
+      brand: 'msi',
+      model: 'gaming x trio',
+      series: '3090',
+      url:
+	      'https://www.pccomponentes.com/msi-geforce-rtx-3090-gaming-x-trio-24gb-gddr6x',
+    },
+    {
+      brand: 'gigabyte',
+      model: 'aorus xtreme',
+      series: '3090',
+      url:
+	      'https://www.pccomponentes.com/gigabyte-aorus-geforce-rtx-3090-xtreme-24gb-gddrx6',
+    },
+    {
+      brand: 'gigabyte',
+      model: 'aorus master',
+      series: '3090',
+      url:
+	      'https://www.pccomponentes.com/gigabyte-aorus-geforce-rtx-3090-master-24gb-gddr6x',
+    },
+    {
+      brand: 'asus',
+      model: 'strix oc',
+      series: '3090',
+      url:
+	      'https://www.pccomponentes.com/asus-rog-strix-geforce-rtx-3090-gaming-oc-24gb-gddr6x',
+    },
+    {
+      brand: 'evga',
+      model: 'ftw3 ultra hybrid',
+      series: '3090',
+      url:
+	      'https://www.pccomponentes.com/evga-geforce-rtx-3090-ftw3-ultra-hybrid-gaming-24gb-gddr6x',
+    },
+    {
+      brand: 'evga',
+      model: 'ftw3 ultra',
+      series: '3090',
+      url:
+	      'https://www.pccomponentes.com/evga-geforce-rtx-3090-ftw3-ultra-gaming-24gb-gddr6x',
+    },
+    {
+      brand: 'gigabyte',
+      model: 'aorus xtreme waterforce wb',
+      series: '3090',
+      url:
+	      'https://www.pccomponentes.com/gigabyte-aorus-geforce-rtx-3090-xtreme-waterforce-wb-24gb-gddr6x',
+    },
+    {
+      brand: 'gigabyte',
+      model: 'eagle oc',
+      series: '3090',
+      url:
+	      'https://www.pccomponentes.com/gigabyte-geforce-rtx-3090-eagle-oc-24g-24gb-gddr6x',
+    },
+    {
+      brand: 'msi',
+      model: 'ventus 3x oc',
+      series: '3090',
+      url:
+	      'https://www.pccomponentes.com/msi-geforce-rtx-3090-ventus-3x-oc-24gb-gddr6x',
+    },
+    {
       brand: 'gigabyte',
       model: 'eagle oc',
       series: '3080',
@@ -312,6 +410,118 @@ export const PCComponentes: Store = {
       series: '3070',
       url:
         'https://www.pccomponentes.com/asus-rog-strix-gaming-geforce-rtx-3070-8gb-gddr6',
+    },
+    {
+      brand: 'msi',
+      model: 'ventus 2x oc',
+      series: '3060ti',
+      url:
+	      'https://www.pccomponentes.com/msi-rtx-3060-ti-ventus-2x-oc-8gb-gddr6',
+    },
+    {
+      brand: 'gigabyte',
+      model: 'eagle oc',
+      series: '3060ti',
+      url:
+	      'https://www.pccomponentes.com/gigabyte-geforce-rtx-3060-ti-eagle-oc-8gb-gddr6',
+    },
+    {
+      brand: 'evga',
+      model: 'ftw3 ultra',
+      series: '3060ti',
+      url:
+	      'https://www.pccomponentes.com/evga-geforce-rtx-3060-ti-ftw3-ultra-8gb-gddr6',
+    },
+    {
+      brand: 'asus',
+      model: 'dual oc',
+      series: '3060ti',
+      url:
+	      'https://www.pccomponentes.com/asus-geforce-rtx-3060ti-dual-o8g-8gb-gddr6',
+    },
+    {
+      brand: 'gigabyte',
+      model: 'gaming oc pro',
+      series: '3060ti',
+      url:
+	      'https://www.pccomponentes.com/gigabyte-geforce-rtx-3060-ti-gaming-oc-pro-8gb-gddr6',
+    },
+    {
+      brand: 'msi',
+      model: 'gaming x trio',
+      series: '3060ti',
+      url:
+	      'https://www.pccomponentes.com/msi-geforce-rtx-3060-ti-gaming-x-8gb-gddr6',
+    },
+    {
+      brand: 'zotac',
+      model: 'twin edge oc',
+      series: '3060ti',
+      url:
+	      'https://www.pccomponentes.com/zotac-geforce-rtx-3060ti-d6-twin-edge-oc-8gb-gddr6',
+    },
+    {
+      brand: 'asus',
+      model: 'strix oc',
+      series: '3060ti',
+      url:
+	      'https://www.pccomponentes.com/asus-rog-strix-geforce-rtx-3060ti-o8g-gaming-8gb-gddr6',
+    },
+    {
+      brand: 'asus',
+      model: 'tuf oc',
+      series: '3060ti',
+      url:
+	      'https://www.pccomponentes.com/asus-tuf-geforce-rtx-3060ti-o8g-gaming-8gb-gddr6',
+    },
+    {
+      brand: 'msi',
+      model: 'gaming x trio',
+      series: '3060ti',
+      url:
+	      'https://www.pccomponentes.com/msi-rtx-3060-ti-gaming-x-trio-8gb-gddr6',
+    },
+    {
+      brand: 'zotac',
+      model: 'twin edge',
+      series: '3060ti',
+      url:
+	      'https://www.pccomponentes.com/zotac-geforce-rtx-3060-ti-d6-twin-edge-8gb-gddr6',
+    },
+    {
+      brand: 'evga',
+      model: 'xc gaming',
+      series: '3060ti',
+      url:
+	      'https://www.pccomponentes.com/evga-geforce-rtx-3060-ti-xc-8gb-gddr6',
+    },
+    {
+      brand: 'gigabyte',
+      model: 'aorus master',
+      series: '3060ti',
+      url:
+	      'https://www.pccomponentes.com/gigabyte-aorus-geforce-rtx-3060-ti-master-8gb-gddr6',
+    },
+    {
+      brand: 'pny',
+      model: 'xlr8 revel',
+      series: '3060ti',
+      url:
+	      'https://www.pccomponentes.com/pny-geforce-rtx-3060ti-xlr8-gaming-revel-epic-x-rgb-edition-8gb-gddr6',
+    },
+    {
+      brand: 'gigabyte',
+      model: 'gaming oc',
+      series: 'rx6900xt',
+      url:
+	      'https://www.pccomponentes.com/gigabyte-radeon-rx-6900-xt-gaming-oc-16gb-gddr6',
+    },
+    {
+      brand: 'asus',
+      model: 'tuf oc',
+      series: 'rx6900xt',
+      url:
+	      'https://www.pccomponentes.com/asus-tuf-amd-radeon-rx-6900xt-oc-16gb-gddr6',
     },
   ],
   name: 'pccomponentes',


### PR DESCRIPTION
Added all the 3090, 3060ti, and rx6900xt series from pccomponentes.

### Description

Pccomponentes was only searching for 3070 and 3080 series. This adds other series currently available on the website.

### Testing
Checked current stock and as there is none it shows out of stock. If necessary I will do further testing.
