### PR TITLE
feat(store): add netonnet-no

### DIFF
--- a/docs/reference/filter.md
+++ b/docs/reference/filter.md
@@ -123,6 +123,7 @@ Used with the `STORES` variable.
 | Mindfactory | DE | `mindfactory` |
 | MSY | AU |  `msy`|
 | Mwave | AU | `mwave`|
+| Netonnet | NO | `netonnet-no`|
 | Newegg | US | `newegg`|
 | Newegg | CA | `newegg-ca`|
 | Newegg | SG | `newegg-sg`|

--- a/src/store/model/index.ts
+++ b/src/store/model/index.ts
@@ -87,6 +87,7 @@ import {MicroCenter} from './microcenter';
 import {Mindfactory} from './mindfactory';
 import {Msy} from './msy';
 import {Mwave} from './mwave';
+import {NetonnetNO} from './netonnet-no';
 import {Newegg} from './newegg';
 import {NeweggCa} from './newegg-ca';
 import {NeweggSg} from './newegg-sg';
@@ -229,6 +230,7 @@ export const storeList = new Map([
   [Mindfactory.name, Mindfactory],
   [Msy.name, Msy],
   [Mwave.name, Mwave],
+  [NetonnetNO.name, NetonnetNO],
   [Newegg.name, Newegg],
   [NeweggCa.name, NeweggCa],
   [NeweggSg.name, NeweggSg],

--- a/src/store/model/netonnet-no.ts
+++ b/src/store/model/netonnet-no.ts
@@ -1,0 +1,158 @@
+import {Store} from './store';
+
+export const NetonnetNO: Store = {
+  currency: 'kr.',
+  labels: {
+    inStock: {
+      container: '#productPurchaseBoxContainer > div > button',
+      text: ['Legg i handlevogn'],
+    },
+    outOfStock: {
+      container: '#productPurchaseBoxContainer > div > button',
+      text: ['Overvåk produktet'],
+    },
+  },
+  links: [
+    {
+      brand: 'test:brand',
+      model: 'test:model',
+      series: 'test:series',
+      url:
+        'https://www.netonnet.no/art/datakomponenter/skjermkort/nvidia/kfa2-geforce-rtx-3090-hall-of-fame/1016867.11111/',
+    },
+    {
+      brand: 'asus',
+      model: 'tuf',
+      series: '3060ti',
+      url:
+        'https://www.netonnet.no/art/datakomponenter/skjermkort/nvidia/asus-geforce-rtx-3060ti-tuf-gaming-8gb/1015570.11111/',
+    },
+    {
+      brand: 'asus',
+      model: 'tuf oc',
+      series: '3060ti',
+      url:
+        'https://www.netonnet.no/art/datakomponenter/skjermkort/nvidia/asus-geforce-rtx-3060ti-tuf-gaming-oc-8gb/1015565.11111/',
+    },
+    {
+      brand: 'asus',
+      model: 'strix oc',
+      series: '3060ti',
+      url:
+        'https://www.netonnet.no/art/datakomponenter/skjermkort/nvidia/asus-geforce-rtx-3060-ti-rog-strix-gaming-oc-8gb/1016449.11111/',
+    },
+    {
+      brand: 'asus',
+      model: 'dual',
+      series: '3060ti',
+      url:
+        'https://www.netonnet.no/art/datakomponenter/skjermkort/nvidia/asus-geforce-rtx-3060ti-dual-oc-8gb/1015673.11111/',
+    },
+    {
+      brand: 'msi',
+      model: 'gaming x trio',
+      series: '3060ti',
+      url:
+        'https://www.netonnet.no/art/datakomponenter/skjermkort/nvidia/msi-geforce-rtx-3060-ti-gaming-x-trio/1015906.11111/',
+    },
+    {
+      brand: 'gigabyte',
+      model: 'eagle',
+      series: '3060ti',
+      url:
+        'https://www.netonnet.no/art/datakomponenter/skjermkort/nvidia/gigabyte-geforce-rtx-3060-ti-eagle-8g/1015575.11111/',
+    },
+    {
+      brand: 'gigabyte',
+      model: 'eagle oc',
+      series: '3060ti',
+      url:
+        'https://www.netonnet.no/art/datakomponenter/skjermkort/nvidia/gigabyte-geforce-rtx-3060-ti-eagle-oc-8g/1015576.11111/',
+    },
+    {
+      brand: 'gigabyte',
+      model: 'aorus master',
+      series: '3060ti',
+      url:
+        'https://www.netonnet.no/art/datakomponenter/skjermkort/nvidia/gigabyte-geforce-rtx-3060-ti-aorus-master/1015582.11111/',
+    },
+    {
+      brand: 'gigabyte',
+      model: 'gaming oc',
+      series: '3060ti',
+      url:
+        'https://www.netonnet.no/art/datakomponenter/skjermkort/nvidia/gigabyte-geforce-rtx-3060-ti-gaming-oc-8gb/1015578.11111/',
+    },
+    {
+      brand: 'gigabyte',
+      model: 'gaming pro oc',
+      series: '3060ti',
+      url:
+        'https://www.netonnet.no/art/datakomponenter/skjermkort/nvidia/gigabyte-geforce-rtx-3060ti-gaming-pro-oc/1016888.11111/',
+    },
+    {
+      brand: 'kfa2',
+      model: 'sg',
+      series: '3060ti',
+      url:
+        'https://www.netonnet.no/art/datakomponenter/skjermkort/nvidia/gigabyte-geforce-rtx-3060ti-gaming-pro-oc/1016888.11111/',
+    },
+    {
+      brand: 'asus',
+      model: 'strix oc',
+      series: '3080',
+      url:
+        'https://www.netonnet.no/art/datakomponenter/skjermkort/nvidia/asus-geforce-rtx-3080-rog-strix-gaming-oc-white-10gb/1015992.11111/',
+    },
+    {
+      brand: 'asus',
+      model: 'strix white',
+      series: '3080',
+      url:
+        'https://www.netonnet.no/art/datakomponenter/skjermkort/nvidia/asus-geforce-rtx-3080-rog-strix-gaming-oc-10gb/1016281.11111/',
+    },
+    {
+      brand: 'asus',
+      model: 'tuf',
+      series: '3080',
+      url:
+        'https://www.netonnet.no/art/datakomponenter/skjermkort/nvidia/asus-geforce-rtx-3080-tuf-gaming-10g/1014354.11111/',
+    },
+    {
+      brand: 'asus',
+      model: 'tuf oc',
+      series: '3080',
+      url:
+        'https://www.netonnet.no/art/datakomponenter/skjermkort/nvidia/asus-geforce-rtx-3080-tuf-gaming-oc-10gb/1015670.11111/',
+    },
+    {
+      brand: 'asus',
+      model: 'strix',
+      series: '3080',
+      url:
+        'https://www.netonnet.no/art/datakomponenter/skjermkort/nvidia/asus-geforce-rtx-3080-rog-strix-gaming-10g/1014394.11111/',
+    },
+    {
+      brand: 'gigabyte',
+      model: 'gaming',
+      series: '3080',
+      url:
+        'https://www.netonnet.no/art/datakomponenter/skjermkort/nvidia/gigabyte-geforce-rtx-3080-gaming-oc-10g/1014380.11111/',
+    },
+    {
+      brand: 'gigabyte',
+      model: 'eagle oc',
+      series: '3080',
+      url:
+        'https://www.netonnet.no/art/datakomponenter/skjermkort/nvidia/gigabyte-geforce-rtx-3080-eagle-oc-10g/1014382.11111/',
+    },
+    {
+      brand: 'gigabyte',
+      model: 'aorus xtreme',
+      series: '3080',
+      url:
+        'https://www.netonnet.no/art/datakomponenter/skjermkort/nvidia/gigabyte-geforce-rtx-3080-aorus-xtream-10gb/1015517.11111/',
+    },
+  ],
+  name: 'netonnet-no',
+};


### PR DESCRIPTION

### Description
Added another norwegian store, netonnet.no - Since it exists in Sweden I let it have -no suffix. 

### Testing
I've tested it with an in stock 3090 which checks out as in-stock and the obvious out of stock 3080's and 3060ti's. 