### PR TITLE
ci: update build cache

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup build cache
         uses: actions/cache@v2
         with:
-          path: ~/.npm
+          path: '**/node_modules'
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
           restore-keys: ${{ runner.os }}-node-
       - name: Install dependencies


### PR DESCRIPTION
### Description

Uses better implementation of `actions/cache` for building npm cache.