### PR TITLE
feat: Refactor notifications and make them injectable

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import {getSleepTime} from './util';
 import {logger} from './logger';
 import {storeList} from './store/model';
 import {tryLookupAndLoop} from './store';
+import {sendNotification} from './notification';
 
 let browser: Browser | undefined;
 
@@ -76,7 +77,13 @@ async function main() {
       store.setupAction(browser);
     }
 
-    setTimeout(tryLookupAndLoop, getSleepTime(store), browser, store);
+    setTimeout(
+      tryLookupAndLoop,
+      getSleepTime(store),
+      browser,
+      store,
+      sendNotification
+    );
   }
 
   await startAPIServer();

--- a/src/notification/link_poll_event.ts
+++ b/src/notification/link_poll_event.ts
@@ -1,0 +1,23 @@
+import {Link, Store} from '../store/model';
+
+type RequestFailed = {
+  failureReason: 'request_failed';
+  statusCode: number;
+};
+type Captcha = {failureReason: 'captcha'};
+type MaxPriceExceeded = {failureReason: 'max_price'; maxPrice: number};
+type OutOfStock = {failureReason: 'out_of_stock'};
+type BannedSeller = {failureReason: 'banned_seller'};
+type LinkPollError = {result: 'failure'} & (
+  | RequestFailed
+  | Captcha
+  | MaxPriceExceeded
+  | OutOfStock
+  | BannedSeller
+);
+type LinkPollSuccess = {result: 'in_stock'};
+
+export type LinkPollEvent = (LinkPollError | LinkPollSuccess) & {
+  link: Link;
+  store: Store;
+};

--- a/src/notification/link_poll_event.ts
+++ b/src/notification/link_poll_event.ts
@@ -15,7 +15,7 @@ type LinkPollError = {result: 'failure'} & (
   | OutOfStock
   | BannedSeller
 );
-type LinkPollSuccess = {result: 'in_stock'};
+type LinkPollSuccess = {result: 'in_stock'; url: string};
 
 export type LinkPollEvent = (LinkPollError | LinkPollSuccess) & {
   link: Link;

--- a/src/notification/logstream.ts
+++ b/src/notification/logstream.ts
@@ -1,0 +1,30 @@
+import {Print, logger} from '../logger';
+import {LinkPollEvent} from './link_poll_event';
+
+function assertNever(x: never): never {
+  throw new Error('Unexpected object: ' + x);
+}
+
+export function sendLogstream(pollEvent: LinkPollEvent) {
+  const {link, store} = pollEvent;
+  if (pollEvent.result === 'failure') {
+    switch (pollEvent.failureReason) {
+      case 'captcha':
+        logger.warn(Print.captcha(link, store, true));
+        return;
+      case 'banned_seller':
+        logger.warn(Print.bannedSeller(link, store, true));
+        return;
+      case 'out_of_stock':
+        logger.info(Print.outOfStock(link, store, true));
+        return;
+      case 'max_price':
+        logger.info(Print.maxPrice(link, store, pollEvent.maxPrice, true));
+        return;
+      case 'request_failed':
+        return;
+      default:
+        assertNever(pollEvent);
+    }
+  }
+}

--- a/src/notification/logstream.ts
+++ b/src/notification/logstream.ts
@@ -7,7 +7,9 @@ function assertNever(x: never): never {
 
 export function sendLogstream(pollEvent: LinkPollEvent) {
   const {link, store} = pollEvent;
-  if (pollEvent.result === 'failure') {
+  if (pollEvent.result === 'in_stock') {
+    logger.info(`${Print.inStock(link, store, true)}\n${pollEvent.url}`);
+  } else {
     switch (pollEvent.failureReason) {
       case 'captcha':
         logger.warn(Print.captcha(link, store, true));

--- a/src/notification/notification.ts
+++ b/src/notification/notification.ts
@@ -1,4 +1,3 @@
-import {Link, Store} from '../store/model';
 import {adjustPhilipsHueLights} from './philips-hue';
 import {playSound} from './sound';
 import {sendDesktopNotification} from './desktop';
@@ -17,57 +16,16 @@ import {sendTwitchMessage} from './twitch';
 import {updateRedis} from './redis';
 import {activateSmartthingsSwitch} from './smartthings';
 import {sendStreamLabsAlert} from './streamlabs';
-import {Print, logger} from '../logger';
-
-type RequestFailed = {
-  failureReason: 'request_failed';
-  statusCode: number;
-};
-type Captcha = {failureReason: 'captcha'};
-type MaxPriceExceeded = {failureReason: 'max_price'; maxPrice: number};
-type OutOfStock = {failureReason: 'out_of_stock'};
-type BannedSeller = {failureReason: 'banned_seller'};
-type LinkPollError = {result: 'failure'} & (
-  | RequestFailed
-  | Captcha
-  | MaxPriceExceeded
-  | OutOfStock
-  | BannedSeller
-);
-type LinkPollSuccess = {result: 'in_stock'};
-
-export type LinkPollEvent = (LinkPollError | LinkPollSuccess) & {
-  link: Link;
-  store: Store;
-};
-export type SendNotification = (pollEvent: LinkPollEvent) => void;
-
-function assertNever(x: never): never {
-  throw new Error('Unexpected object: ' + x);
-}
+import {sendLogstream} from './logstream';
+import {LinkPollEvent} from './link_poll_event';
 
 export function sendNotification(pollEvent: LinkPollEvent) {
-  const {link, store} = pollEvent;
+  sendLogstream(pollEvent);
   if (pollEvent.result === 'failure') {
-    switch (pollEvent.failureReason) {
-      case 'captcha':
-        logger.warn(Print.captcha(link, store, true));
-        return;
-      case 'banned_seller':
-        logger.warn(Print.bannedSeller(link, store, true));
-        return;
-      case 'out_of_stock':
-        logger.info(Print.outOfStock(link, store, true));
-        return;
-      case 'max_price':
-        logger.info(Print.maxPrice(link, store, pollEvent.maxPrice, true));
-        return;
-      case 'request_failed':
-        return;
-      default:
-        assertNever(pollEvent);
-    }
+    return;
   }
+
+  const {link, store} = pollEvent;
   // Priority
   playSound();
   sendDiscordMessage(link, store);

--- a/src/notification/notification.ts
+++ b/src/notification/notification.ts
@@ -17,8 +17,57 @@ import {sendTwitchMessage} from './twitch';
 import {updateRedis} from './redis';
 import {activateSmartthingsSwitch} from './smartthings';
 import {sendStreamLabsAlert} from './streamlabs';
+import {Print, logger} from '../logger';
 
-export function sendNotification(link: Link, store: Store) {
+type RequestFailed = {
+  failureReason: 'request_failed';
+  statusCode: number;
+};
+type Captcha = {failureReason: 'captcha'};
+type MaxPriceExceeded = {failureReason: 'max_price'; maxPrice: number};
+type OutOfStock = {failureReason: 'out_of_stock'};
+type BannedSeller = {failureReason: 'banned_seller'};
+type LinkPollError = {result: 'failure'} & (
+  | RequestFailed
+  | Captcha
+  | MaxPriceExceeded
+  | OutOfStock
+  | BannedSeller
+);
+type LinkPollSuccess = {result: 'in_stock'};
+
+export type LinkPollEvent = (LinkPollError | LinkPollSuccess) & {
+  link: Link;
+  store: Store;
+};
+export type SendNotification = (pollEvent: LinkPollEvent) => void;
+
+function assertNever(x: never): never {
+  throw new Error('Unexpected object: ' + x);
+}
+
+export function sendNotification(pollEvent: LinkPollEvent) {
+  const {link, store} = pollEvent;
+  if (pollEvent.result === 'failure') {
+    switch (pollEvent.failureReason) {
+      case 'captcha':
+        logger.warn(Print.captcha(link, store, true));
+        return;
+      case 'banned_seller':
+        logger.warn(Print.bannedSeller(link, store, true));
+        return;
+      case 'out_of_stock':
+        logger.info(Print.outOfStock(link, store, true));
+        return;
+      case 'max_price':
+        logger.info(Print.maxPrice(link, store, pollEvent.maxPrice, true));
+        return;
+      case 'request_failed':
+        return;
+      default:
+        assertNever(pollEvent);
+    }
+  }
   // Priority
   playSound();
   sendDiscordMessage(link, store);

--- a/src/store/lookup.ts
+++ b/src/store/lookup.ts
@@ -23,7 +23,7 @@ import {filterStoreLink} from './filter';
 import open from 'open';
 import {processBackoffDelay} from './model/helpers/backoff';
 import useProxy from '@doridian/puppeteer-page-proxy';
-import {LinkPollEvent} from "../notification/link_poll_event";
+import {LinkPollEvent} from '../notification/link_poll_event';
 
 const inStock: Record<string, boolean> = {};
 
@@ -331,7 +331,6 @@ async function lookupCard(
   if (await lookupCardInStock(store, page, link, sendNotification)) {
     const givenUrl =
       link.cartUrl && config.store.autoAddToCart ? link.cartUrl : link.url;
-    logger.info(`${Print.inStock(link, store, true)}\n${givenUrl}`);
 
     if (config.browser.open) {
       await (link.openCartAction === undefined
@@ -341,6 +340,7 @@ async function lookupCard(
 
     sendNotification({
       result: 'in_stock',
+      url: givenUrl,
       link,
       store,
     });

--- a/src/store/lookup.ts
+++ b/src/store/lookup.ts
@@ -22,12 +22,14 @@ import {fetchLinks} from './fetch-links';
 import {filterStoreLink} from './filter';
 import open from 'open';
 import {processBackoffDelay} from './model/helpers/backoff';
-import {SendNotification} from '../notification';
 import useProxy from '@doridian/puppeteer-page-proxy';
+import {LinkPollEvent} from "../notification/link_poll_event";
 
 const inStock: Record<string, boolean> = {};
 
 const linkBuilderLastRunTimes: Record<string, number> = {};
+
+export type SendNotification = (pollEvent: LinkPollEvent) => void;
 
 function nextProxy(store: Store) {
   if (!store.proxyList) {

--- a/test/functional/test-notification.ts
+++ b/test/functional/test-notification.ts
@@ -27,7 +27,7 @@ const store: Store = {
 /**
  * Send test email.
  */
-sendNotification(link, store);
+sendNotification({result: 'in_stock', link, store});
 
 /**
  * Open browser.

--- a/test/functional/test-notification.ts
+++ b/test/functional/test-notification.ts
@@ -27,7 +27,7 @@ const store: Store = {
 /**
  * Send test email.
  */
-sendNotification({result: 'in_stock', link, store});
+sendNotification({result: 'in_stock', url: 'test:url', link, store});
 
 /**
  * Open browser.


### PR DESCRIPTION
<!-- Please use Conventional Commits to label your title -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/ -->
<!-- Example: feat: allow provided config object to extend other configs  -->

### Description

First I think it's worth giving context to what my goal is. I would like to create a program that wraps streetmerchant and offers another dashboard. I would like for it to run in the same process and avoid adding infrastructure if at all possible.

This PR refactors the notifications to make both failures and success notifications. It also makes the notification function injectable, but the `main` function uses the existing one.

I also refactored to make the logging of failures as part of normal notifications. This isn't strictly necessary but I thought it was nice to harmonize both and show that logging is just one way to handle poll events.

This PR, along with https://github.com/jef/streetmerchant/compare/main...gmalette:gm/packaging?expand=1, allow me to use streetmerchant and inject notification handling.

```ts
import {Browser, launch} from 'puppeteer';
import {config} from 'streetmerchant/build/src/config';
import {getSleepTime} from 'streetmerchant/build/src/util';
import {storeList} from 'streetmerchant/build/src/store/model';
import {tryLookupAndLoop} from 'streetmerchant/build/src/store';
import {LinkPollEvent} from 'streetmerchant/build/src/notification/link_poll_event';

const sendNotification = (event: LinkPollEvent): void => {
  console.log(event);
};

async function main() {
  const args: string[] = [];
  const browser: Browser = await launch({
    args,
    defaultViewport: {
      height: config.page.height,
      width: config.page.width,
    },
    headless: config.browser.isHeadless,
  });

  config.browser.userAgent = await browser.userAgent();

  for (const store of storeList.values()) {
    if (store.setupAction !== undefined) {
      store.setupAction(browser);
    }

    setTimeout(tryLookupAndLoop, getSleepTime(store), browser, store, sendNotification);
  }
}

void main();
```

### Testing

Ran the program, worked as normal for "out of stock" and other errors.
I was not able to test for "in stock" items.


