### PR TITLE
chore(store): add 3060 for mediamarkt, saturn and notebooksbilliger

### DIFF
--- a/docs/reference/filter.md
+++ b/docs/reference/filter.md
@@ -214,7 +214,7 @@ Used with the `SHOW_ONLY_BRANDS` and `SHOW_ONLY_MODELS` variables.
 | `pny` | `dual fan`, `xlr8 epic x`, `xlr8 revel`, `xlr8 uprising` |
 | `sony` | `ps5 console`, `ps5 digital` |
 | `xfx` | `merc`, `amd reference` |
-| `zotac` | `amp holo`, `amp extreme holo`, `trinity`, `trinity oc`, `twin edge`, `twin edge oc`, `twin edge oc white` |
+| `zotac` | `amp holo`, `amp extreme holo`, `amp white`, `trinity`, `trinity oc`, `twin edge`, `twin edge oc`, `twin edge oc white` |
 
 ## Supported series
 

--- a/src/store/model/mediamarkt.ts
+++ b/src/store/model/mediamarkt.ts
@@ -43,6 +43,18 @@ export const Mediamarkt: Store = {
       url: 'https://www.mediamarkt.de/de/product/-2641856.html',
     },
     {
+      brand: 'inno3d',
+      model: 'ichill x3',
+      series: '3060',
+      url: 'https://www.mediamarkt.de/de/product/-2718593.html',
+    },
+    {
+      brand: 'inno3d',
+      model: 'twin x2 oc',
+      series: '3060',
+      url: 'https://www.mediamarkt.de/de/product/-2718594.html',
+    },
+    {
       brand: 'asus',
       model: 'dual',
       series: '3060ti',

--- a/src/store/model/notebooksbilliger.ts
+++ b/src/store/model/notebooksbilliger.ts
@@ -46,6 +46,76 @@ export const Notebooksbilliger: Store = {
         'https://www.notebooksbilliger.de/gainward+geforce+rtx+2070+super+phoenix+v1+grafikkarte+656238',
     },
     {
+      brand: 'asus',
+      model: 'strix',
+      series: '3060',
+      url:
+        'https://www.notebooksbilliger.de/asus+rog+strix+geforce+rtx+3060+oc+12g+grafikkarte+702541',
+    },
+    {
+      brand: 'gigabyte',
+      model: 'gaming oc',
+      series: '3060',
+      url:
+        'https://www.notebooksbilliger.de/gigabyte+geforce+rtx+3060+gaming+oc+12gb+gddr6+grafikkarte+700421',
+    },
+    {
+      brand: 'gigabyte',
+      model: 'eagle oc',
+      series: '3060',
+      url:
+        'https://www.notebooksbilliger.de/gigabyte+geforce+rtx+3060+eagle+oc+12gb+gddr6+grafikkarte+700422',
+    },
+    {
+      brand: 'inno3d',
+      model: 'twin x2 oc',
+      series: '3060',
+      url:
+        'https://www.notebooksbilliger.de/inno3d+geforce+rtx+3060+12gb+twin+x2+oc+701384',
+    },
+    {
+      brand: 'inno3d',
+      model: 'ichill x3',
+      series: '3060',
+      url:
+        'https://www.notebooksbilliger.de/inno3d+geforce+rtx+3060+12gb+ichill+x3+red+701383?',
+    },
+    {
+      brand: 'palit',
+      model: 'dual',
+      series: '3060',
+      url:
+        'https://www.notebooksbilliger.de/palit+geforce+rtx+3060+12gb+dual+702252',
+    },
+    {
+      brand: 'palit',
+      model: 'dual oc',
+      series: '3060',
+      url:
+        'https://www.notebooksbilliger.de/palit+geforce+rtx+3060+12gb+dual+oc+gddr6+702251',
+    },
+    {
+      brand: 'pny',
+      model: 'xlr8 gaming',
+      series: '3060',
+      url:
+        'https://www.notebooksbilliger.de/pny+geforce+rtx+3060+12gb+xlr8+gaming+revel+epic+x+rgb+single+701885',
+    },
+    {
+      brand: 'zotac',
+      model: 'amp white',
+      series: '3060',
+      url:
+        'https://www.notebooksbilliger.de/zotac+geforce+rtx+3060+amp+white+12gb+gddr6+grafikkarte+701867',
+    },
+    {
+      brand: 'zotac',
+      model: 'twin edge oc',
+      series: '3060',
+      url:
+        'https://www.notebooksbilliger.de/zotac+gaming+geforce+rtx+3060+twin+edge+oc+12gb+grafikkarte+700378',
+    },
+    {
       brand: 'inno3d',
       model: 'ichill x3',
       series: '3070',

--- a/src/store/model/saturn.ts
+++ b/src/store/model/saturn.ts
@@ -43,6 +43,18 @@ export const Saturn: Store = {
       url: 'https://www.saturn.de/de/product/-2641856.html',
     },
     {
+      brand: 'inno3d',
+      model: 'ichill x3',
+      series: '3060',
+      url: 'https://www.saturn.de/de/product/-2718593.html',
+    },
+    {
+      brand: 'inno3d',
+      model: 'twin x2 oc',
+      series: '3060',
+      url: 'https://www.saturn.de/de/product/-2718594.html',
+    },
+    {
       brand: 'asus',
       model: 'dual',
       series: '3060ti',

--- a/src/store/model/store.ts
+++ b/src/store/model/store.ts
@@ -71,6 +71,7 @@ export type Model =
   | 'amd reference'
   | 'amp extreme holo'
   | 'amp holo'
+  | 'amp white'
   | 'aorus master'
   | 'aorus master type-c'
   | 'aorus xtreme'


### PR DESCRIPTION
### Description

Adds all RTX3060 I could find to notebooksbilliger and mediamarkt/saturn
For mediamarkt/saturn I could only find 2 product URLs for the time being.

### Testing

I ran the bot with the added URL and it seems to work fine.
I verified all URLs to work.