### PR TITLE
fix(lookup): check in stock before price

### DIFF
--- a/src/store/lookup.ts
+++ b/src/store/lookup.ts
@@ -438,17 +438,6 @@ async function lookupCardInStock(store: Store, page: Page, link: Link) {
     }
   }
 
-  if (store.labels.maxPrice) {
-    const maxPrice = config.store.maxPrice.series[link.series];
-
-    link.price = await getPrice(page, store.labels.maxPrice, baseOptions);
-
-    if (link.price && link.price > maxPrice && maxPrice > 0) {
-      logger.info(Print.maxPrice(link, store, maxPrice, true));
-      return false;
-    }
-  }
-
   // Fixme: currently causing issues
   // Do API inventory validation in realtime (no cache) if available
   // if (
@@ -480,6 +469,17 @@ async function lookupCardInStock(store: Store, page: Page, link: Link) {
 
     if (!(await pageIncludesLabels(page, link.labels.inStock, options))) {
       logger.info(Print.outOfStock(link, store, true));
+      return false;
+    }
+  }
+
+  if (store.labels.maxPrice) {
+    const maxPrice = config.store.maxPrice.series[link.series];
+
+    link.price = await getPrice(page, store.labels.maxPrice, baseOptions);
+
+    if (link.price && link.price > maxPrice && maxPrice > 0) {
+      logger.info(Print.maxPrice(link, store, maxPrice, true));
       return false;
     }
   }


### PR DESCRIPTION
### Description

I long meant to make that simple change.. In the same vein as #1422, ensure the item is in stock before printing an error based on a price check. This makes the output of streetmerchant more useful as out of stock items will appear out of stock.. and only when an item is in stock but does not match our price requirements, will we print the price range mismatch. If the price is just barely out of the range but seems still acceptable for the user, it gives them the actionable opportunity to place an order. Otherwise, the price mismatch messages are simply noise.
