### PR TITLE
chore(amd): update rx6900xt urls

### DIFF
--- a/src/store/model/amd.ts
+++ b/src/store/model/amd.ts
@@ -54,10 +54,10 @@ export const Amd: Store = {
     {
       brand: 'amd',
       cartUrl:
-        'https://www.amd.com/en/direct-buy/5458372200/us?add-to-cart=true',
+        'https://www.amd.com/en/direct-buy/5458374200/us?add-to-cart=true',
       model: 'amd reference',
       series: 'rx6900xt',
-      url: 'https://www.amd.com/en/direct-buy/5458372200/us',
+      url: 'https://www.amd.com/en/direct-buy/5458374200/us',
     },
     {
       brand: 'amd',


### PR DESCRIPTION
<!-- Please use Conventional Commits to label your title -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/ -->
<!-- Example: feat: allow provided config object to extend other configs  -->

### Description

6900RX URL have changed, it is now [https://www.amd.com/en/direct-buy/5458374200/[locale]](https://www.amd.com/en/direct-buy/5458374200/us)

<!-- Fixes #(issue) -->
<!-- Please also include relevant motivation and context. -->

### Testing

If you go to the former [URL](https://www.amd.com/en/direct-buy/5458372200/us). This will redirect you to the list of products, and wrongly state that the product is in stock, changing to the new url fixes that issue

<!-- Please describe the tests that you ran to verify your changes. -->
<!-- Provide instructions so we can reproduce. -->
<!-- Please also list any relevant details for your test configuration -->

### New dependencies

<!-- List any dependencies that are required for this change. -->
<!-- Otherwise, delete section. -->
