### PR TITLE
NEEDS TESTING: Added lookupDelay with ASUS configuration

### DIFF
--- a/src/store/lookup.ts
+++ b/src/store/lookup.ts
@@ -408,6 +408,10 @@ async function checkIsCloudflare(store: Store, page: Page, link: Link) {
 }
 
 async function lookupCardInStock(store: Store, page: Page, link: Link) {
+  if (store.lookupDelay) {
+    await delay(store.lookupDelay);
+  }
+
   const baseOptions: Selector = {
     requireVisible: false,
     selector: store.labels.container ?? 'body',

--- a/src/store/model/asus.ts
+++ b/src/store/model/asus.ts
@@ -163,6 +163,7 @@ export const Asus: Store = {
       url: 'https://store.asus.com/us/item/202011AM200000003',
     },
   ],
+  lookupDelay: 3000,
   name: 'asus',
   realTimeInventoryLookup: async (itemNumber: string) => {
     const request_url = 'https://store.asus.com/us/category/get_real_time_data';

--- a/src/store/model/store.ts
+++ b/src/store/model/store.ts
@@ -222,6 +222,7 @@ export type Store = {
     urls: Array<{series: Series; url: string | string[]}>;
   };
   labels: Labels;
+  lookupDelay: number;
   name: string;
   currency: '£' | '$' | '€' | 'R$' | 'kr.' | '';
   setupAction?: (browser: Browser) => void;


### PR DESCRIPTION
### Description
The Asus store uses an anti-bot feature to show "add to cart" briefly before changing to an out of stock button. This fix circumvents that by delaying a configured amount of time per store (when specified). This is an untested PR, but can serve as a foundation for a fix if it does not function out of the box.

<!-- Fixes #(issue) -->
Fixes: https://github.com/jef/streetmerchant/issues/1901

### Testing
Run app, ensure calls to asus.com do not report false positives.
