### PR TITLE
!refactor: drop parameter euroformat and replace it with autodetection by Regex

### DIFF
--- a/src/store/includes-labels.ts
+++ b/src/store/includes-labels.ts
@@ -125,9 +125,9 @@ export async function getPrice(
   const priceString = await extractPageContents(page, selector);
 
   if (priceString) {
-    const priceSeparator = query.euroFormat ? /\./g : /,/g;
+    const priceSeparator =  /\\.|\\,/g;
     const price = Number.parseFloat(
-      priceString.replace(priceSeparator, '').match(/\d+/g)!.join('.')
+      priceString.replace(/\\.|\\,/g, '').match(/\d+/g)!.join('.')
     );
 
     logger.debug('received price', price);

--- a/src/store/model/acompc.ts
+++ b/src/store/model/acompc.ts
@@ -8,8 +8,7 @@ export const AComPC: Store = {
       text: ['lagernd', 'im Zulauf'],
     },
     maxPrice: {
-      container: '.price',
-      euroFormat: true,
+      container: '.price'
     },
     outOfStock: [
       {

--- a/src/store/model/adorama.ts
+++ b/src/store/model/adorama.ts
@@ -12,8 +12,7 @@ export const Adorama: Store = {
       text: ['add to cart'],
     },
     maxPrice: {
-      container: '.your-price',
-      euroFormat: false,
+      container: '.your-price'
     },
   },
   links: [

--- a/src/store/model/akinformatica.ts
+++ b/src/store/model/akinformatica.ts
@@ -14,8 +14,7 @@ export const Akinformatica: Store = {
       },
     ],
     maxPrice: {
-      container: '#PrezzoListinoIvatoLabel',
-      euroFormat: true,
+      container: '#PrezzoListinoIvatoLabel'
     },
     outOfStock: [
       {

--- a/src/store/model/allneeds.ts
+++ b/src/store/model/allneeds.ts
@@ -9,8 +9,7 @@ export const Allneeds: Store = {
       text: ['In Stock'],
     },
     maxPrice: {
-      container: 'span.price',
-      euroFormat: false,
+      container: 'span.price'
     },
     outOfStock: {
       container: '.amstockstatus',

--- a/src/store/model/alternate-nl.ts
+++ b/src/store/model/alternate-nl.ts
@@ -8,8 +8,7 @@ export const AlternateNL: Store = {
       text: ['Direct leverbaar'],
     },
     maxPrice: {
-      container: 'div.price > span',
-      euroFormat: true,
+      container: 'div.price > span'
     },
     outOfStock: {
       container: '.stockStatus',

--- a/src/store/model/alternate.ts
+++ b/src/store/model/alternate.ts
@@ -13,8 +13,7 @@ export const Alternate: Store = {
       ],
     },
     maxPrice: {
-      container: 'div.price > span',
-      euroFormat: true,
+      container: 'div.price > span'
     },
     outOfStock: [
       {

--- a/src/store/model/amazon-de-warehouse.ts
+++ b/src/store/model/amazon-de-warehouse.ts
@@ -16,8 +16,7 @@ export const AmazonDeWarehouse: Store = {
       text: ['In den Einkaufswagen'],
     },
     maxPrice: {
-      container: '.olpOfferPrice',
-      euroFormat: true,
+      container: '.olpOfferPrice'
     },
     outOfStock: [
       {

--- a/src/store/model/amazon-de.ts
+++ b/src/store/model/amazon-de.ts
@@ -16,8 +16,7 @@ export const AmazonDe: Store = {
       text: ['in den einkaufswagen'],
     },
     maxPrice: {
-      container: '#priceblock_ourprice',
-      euroFormat: true,
+      container: '#priceblock_ourprice'
     },
     outOfStock: [
       {

--- a/src/store/model/amazon-fr.ts
+++ b/src/store/model/amazon-fr.ts
@@ -13,8 +13,7 @@ export const AmazonFr: Store = {
       text: ['ajouter au panier'],
     },
     maxPrice: {
-      container: '#priceblock_ourprice',
-      euroFormat: true,
+      container: '#priceblock_ourprice'
     },
     outOfStock: [
       {

--- a/src/store/model/amazon-it.ts
+++ b/src/store/model/amazon-it.ts
@@ -13,8 +13,7 @@ export const AmazonIt: Store = {
       text: ['Aggiungi al carrello'],
     },
     maxPrice: {
-      container: '#priceblock_ourprice',
-      euroFormat: true,
+      container: '#priceblock_ourprice'
     },
   },
   links: [

--- a/src/store/model/amazon-nl.ts
+++ b/src/store/model/amazon-nl.ts
@@ -18,8 +18,7 @@ export const AmazonNl: Store = {
       },
     ],
     maxPrice: {
-      container: '#priceblock_ourprice',
-      euroFormat: true,
+      container: '#priceblock_ourprice'
     },
     outOfStock: [
       {

--- a/src/store/model/amd-ca.ts
+++ b/src/store/model/amd-ca.ts
@@ -8,8 +8,7 @@ export const AmdCa: Store = {
       text: ['add to cart'],
     },
     maxPrice: {
-      container: '.product-page-description h4',
-      euroFormat: false,
+      container: '.product-page-description h4'
     },
   },
   links: [

--- a/src/store/model/amd-de.ts
+++ b/src/store/model/amd-de.ts
@@ -8,8 +8,7 @@ export const AmdDe: Store = {
       text: ['add to cart'],
     },
     maxPrice: {
-      container: '.product-page-description h4',
-      euroFormat: true,
+      container: '.product-page-description h4'
     },
     outOfStock: {
       container: '.btn-radeon',

--- a/src/store/model/amd-it.ts
+++ b/src/store/model/amd-it.ts
@@ -8,8 +8,7 @@ export const AmdIt: Store = {
       text: ['add to cart'],
     },
     maxPrice: {
-      container: '.product-page-description h4',
-      euroFormat: true,
+      container: '.product-page-description h4'
     },
   },
   links: [

--- a/src/store/model/amd-uk.ts
+++ b/src/store/model/amd-uk.ts
@@ -14,8 +14,7 @@ export const AmdUk: Store = {
       },
     ],
     maxPrice: {
-      container: '.product-page-description h4',
-      euroFormat: false,
+      container: '.product-page-description h4'
     },
     outOfStock: [
       {

--- a/src/store/model/amd.ts
+++ b/src/store/model/amd.ts
@@ -8,8 +8,7 @@ export const Amd: Store = {
       text: ['add to cart'],
     },
     maxPrice: {
-      container: '.product-page-description h4',
-      euroFormat: false,
+      container: '.product-page-description h4'
     },
   },
   links: [

--- a/src/store/model/antonline.ts
+++ b/src/store/model/antonline.ts
@@ -8,8 +8,7 @@ export const AntOnline: Store = {
       text: ['Add to Cart'],
     },
     maxPrice: {
-      container: '.cPrice',
-      euroFormat: false,
+      container: '.cPrice'
     },
     outOfStock: {
       container: '.priceView-price .priceView-hero-price span',

--- a/src/store/model/aria.ts
+++ b/src/store/model/aria.ts
@@ -9,8 +9,7 @@ export const Aria: Store = {
       text: ['add to shopping basket'],
     },
     maxPrice: {
-      container: '.priceBig',
-      euroFormat: false, // Note: Aria uses non-euroFromat as price seperator
+      container: '.priceBig'
     },
     outOfStock: {
       container: '.fBox',

--- a/src/store/model/arlt.ts
+++ b/src/store/model/arlt.ts
@@ -8,8 +8,7 @@ export const Arlt: Store = {
       text: ['auf Lager', 'Lieferzeit 2-3 Werktage', 'Ware im Zulauf'],
     },
     maxPrice: {
-      container: '.articleprice .price',
-      euroFormat: true,
+      container: '.articleprice .price'
     },
     outOfStock: {
       container: '.articleDesc .shippingtext',

--- a/src/store/model/awd.ts
+++ b/src/store/model/awd.ts
@@ -9,8 +9,7 @@ export const Awd: Store = {
       text: ['item(s)'],
     },
     maxPrice: {
-      container: '.ty-price',
-      euroFormat: false, // Note: Awd uses non-euroFromat as price seperator
+      container: '.ty-price'
     },
     outOfStock: {
       container: '.vs-stock.ty-float-left',

--- a/src/store/model/azerty.ts
+++ b/src/store/model/azerty.ts
@@ -8,8 +8,7 @@ export const Azerty: Store = {
       text: ['Volgende werkdag in huis', '1 werkdag', '2-3 werkdagen'],
     },
     maxPrice: {
-      container: '.mod_article .price',
-      euroFormat: true,
+      container: '.mod_article .price'
     },
     outOfStock: {
       container: '.orderdelay',

--- a/src/store/model/bandh.ts
+++ b/src/store/model/bandh.ts
@@ -9,8 +9,7 @@ export const BAndH: Store = {
       text: ['add to cart'],
     },
     maxPrice: {
-      container: 'div[data-selenium="pricingPrice"]',
-      euroFormat: false,
+      container: 'div[data-selenium="pricingPrice"]'
     },
     outOfStock: {
       container: 'button[data-selenium="notifyAvailabilityButton"]',

--- a/src/store/model/bestbuy-ca.ts
+++ b/src/store/model/bestbuy-ca.ts
@@ -4,8 +4,7 @@ export const BestBuyCa: Store = {
   currency: '$',
   labels: {
     maxPrice: {
-      container: 'div[class*="pricingContainer"]',
-      euroFormat: false,
+      container: 'div[class*="pricingContainer"]'
     },
     outOfStock: {
       container: '.addToCartButton:disabled',

--- a/src/store/model/box.ts
+++ b/src/store/model/box.ts
@@ -10,8 +10,7 @@ export const Box: Store = {
       text: ['add to basket'],
     },
     maxPrice: {
-      container: '.p-price',
-      euroFormat: false, // Note: Box uses non-euroFromat as price seperator
+      container: '.p-price'
     },
     outOfStock: {
       container: '#divBuyButton',

--- a/src/store/model/bpctech.ts
+++ b/src/store/model/bpctech.ts
@@ -9,8 +9,7 @@ export const Bpctech: Store = {
       text: ['in stock'],
     },
     maxPrice: {
-      container: 'div.price-box.price-final_price > span > span',
-      euroFormat: false,
+      container: 'div.price-box.price-final_price > span > span'
     },
   },
   links: [

--- a/src/store/model/bpmpower.ts
+++ b/src/store/model/bpmpower.ts
@@ -8,8 +8,7 @@ export const BpmPower: Store = {
       text: ['Disponibile'],
     },
     maxPrice: {
-      container: 'p.prezzoScheda:nth-child(1)',
-      euroFormat: true,
+      container: 'p.prezzoScheda:nth-child(1)'
     },
     outOfStock: {
       container: '.dispoSiProd >span',

--- a/src/store/model/canadacomputers.ts
+++ b/src/store/model/canadacomputers.ts
@@ -8,8 +8,7 @@ export const CanadaComputers: Store = {
       text: ['Online In Stock'],
     },
     maxPrice: {
-      container: '.h2-big > strong:nth-child(1)',
-      euroFormat: false,
+      container: '.h2-big > strong:nth-child(1)'
     },
   },
   links: [

--- a/src/store/model/caseking.ts
+++ b/src/store/model/caseking.ts
@@ -9,8 +9,7 @@ export const Caseking: Store = {
       text: ['lagernd', 'im zulauf', 'ab'],
     },
     maxPrice: {
-      container: '#buybox .article_details_price',
-      euroFormat: true,
+      container: '#buybox .article_details_price'
     },
     outOfStock: {
       container: '.delivery_container',

--- a/src/store/model/ccl.ts
+++ b/src/store/model/ccl.ts
@@ -10,8 +10,7 @@ export const Ccl: Store = {
       text: ['add to basket'],
     },
     maxPrice: {
-      container: '#pnlPriceText > p',
-      euroFormat: false, // Note: CCL uses non-euroFromat as price seperator
+      container: '#pnlPriceText > p'
     },
     outOfStock: {
       container: '#pnlSoldOut',

--- a/src/store/model/centrecom.ts
+++ b/src/store/model/centrecom.ts
@@ -9,8 +9,7 @@ export const Centrecom: Store = {
       text: ['In Stock'],
     },
     maxPrice: {
-      container: 'div.prod_price_current.product-price > span',
-      euroFormat: false,
+      container: 'div.prod_price_current.product-price > span'
     },
     outOfStock: {
       container: '.prod_stores_stock > li:nth-child(1) > span:nth-child(2)',

--- a/src/store/model/computeralliance.ts
+++ b/src/store/model/computeralliance.ts
@@ -10,8 +10,7 @@ export const ComputerAlliance: Store = {
       text: ['In Stock'],
     },
     maxPrice: {
-      container: 'span.price',
-      euroFormat: false,
+      container: 'span.price'
     },
     outOfStock: {
       container:

--- a/src/store/model/computeruniverse.ts
+++ b/src/store/model/computeruniverse.ts
@@ -12,8 +12,7 @@ export const Computeruniverse: Store = {
       ],
     },
     maxPrice: {
-      container: '.product-price',
-      euroFormat: true,
+      container: '.product-price'
     },
     outOfStock: {
       container: '.availability',

--- a/src/store/model/coolblue.ts
+++ b/src/store/model/coolblue.ts
@@ -8,8 +8,7 @@ export const Coolblue: Store = {
       text: ['bestel snel', 'morgen in huis'],
     },
     maxPrice: {
-      container: '.js-order-block .sales-price__current',
-      euroFormat: true,
+      container: '.js-order-block .sales-price__current'
     },
     outOfStock: {
       container: '.product-order',

--- a/src/store/model/coolmod.ts
+++ b/src/store/model/coolmod.ts
@@ -8,8 +8,7 @@ export const Coolmod: Store = {
       text: ['Envío'],
     },
     maxPrice: {
-      container: '.text-price-total',
-      euroFormat: true,
+      container: '.text-price-total'
     },
     outOfStock: {
       container: '.product-availability',

--- a/src/store/model/corsair.ts
+++ b/src/store/model/corsair.ts
@@ -8,8 +8,7 @@ export const Corsair: Store = {
       text: ['add to cart'],
     },
     maxPrice: {
-      container: '.product-price',
-      euroFormat: false,
+      container: '.product-price'
     },
   },
   links: [

--- a/src/store/model/currys.ts
+++ b/src/store/model/currys.ts
@@ -9,8 +9,7 @@ export const Currys: Store = {
       text: ['add to basket'],
     },
     maxPrice: {
-      container: '#product-actions span[class*="ProductPriceBlock__Price"]',
-      euroFormat: false, // Note: Currys uses non-euroFromat as price seperator
+      container: '#product-actions span[class*="ProductPriceBlock__Price"]'
     },
     outOfStock: {
       container: '#product-actions .unavailable',

--- a/src/store/model/cyberport.ts
+++ b/src/store/model/cyberport.ts
@@ -8,8 +8,7 @@ export const Cyberport: Store = {
       text: ['sofort verfügbar'],
     },
     maxPrice: {
-      container: '#productDetailOverview .price',
-      euroFormat: true,
+      container: '#productDetailOverview .price'
     },
     outOfStock: {
       container: '.tooltipAvailabilityParent',

--- a/src/store/model/dcomp.ts
+++ b/src/store/model/dcomp.ts
@@ -9,8 +9,7 @@ export const Dcomp: Store = {
       text: ['Add to', ''],
     },
     maxPrice: {
-      container: '#prodprice',
-      euroFormat: false,
+      container: '#prodprice'
     },
     outOfStock: {
       container: '#cart-info > button.btn.notifyMe',

--- a/src/store/model/drako.ts
+++ b/src/store/model/drako.ts
@@ -10,8 +10,7 @@ export const Drako: Store = {
       },
     ],
     maxPrice: {
-      container: '.price',
-      euroFormat: true,
+      container: '.price'
     },
   },
   links: [

--- a/src/store/model/ebuyer.ts
+++ b/src/store/model/ebuyer.ts
@@ -9,8 +9,7 @@ export const Ebuyer: Store = {
       text: ['add to basket', 'pre-order'],
     },
     maxPrice: {
-      container: '.purchase-info__price .price',
-      euroFormat: false, // Note: ebuyer uses non-euroFromat as price seperator
+      container: '.purchase-info__price .price'
     },
     outOfStock: {
       container: '.purchase-info',

--- a/src/store/model/elcorteingles.ts
+++ b/src/store/model/elcorteingles.ts
@@ -18,8 +18,7 @@ export const Elcorteingles: Store = {
       },
     ],
     maxPrice: {
-      container: '.product_detail-buy-price-container .price._big',
-      euroFormat: true,
+      container: '.product_detail-buy-price-container .price._big'
     },
     outOfStock: [
       {

--- a/src/store/model/eprice.ts
+++ b/src/store/model/eprice.ts
@@ -8,8 +8,7 @@ export const Eprice: Store = {
       text: ['disponibile', 'pochi pezzi'],
     },
     maxPrice: {
-      container: '#PrezzoClasic span[class*="big"]',
-      euroFormat: true,
+      container: '#PrezzoClasic span[class*="big"]'
     },
     outOfStock: {
       container: '.dispo',

--- a/src/store/model/equippr.ts
+++ b/src/store/model/equippr.ts
@@ -8,8 +8,7 @@ export const Equippr: Store = {
       text: ['in den warenkorb'],
     },
     maxPrice: {
-      container: '.product--price',
-      euroFormat: true,
+      container: '.product--price'
     },
     outOfStock: {
       container: '.product--buybox',

--- a/src/store/model/euronics-de.ts
+++ b/src/store/model/euronics-de.ts
@@ -8,8 +8,7 @@ export const EuronicsDE: Store = {
       text: ['Warenkorb'],
     },
     maxPrice: {
-      container: '.price--content',
-      euroFormat: true,
+      container: '.price--content'
     },
     outOfStock: {
       container:

--- a/src/store/model/evatech.ts
+++ b/src/store/model/evatech.ts
@@ -9,8 +9,7 @@ export const Evatech: Store = {
       text: ['ADD TO CART'],
     },
     maxPrice: {
-      container: '.product_detail_price',
-      euroFormat: false,
+      container: '.product_detail_price'
     },
     outOfStock: {
       container: '.product_detail_add_to_cart > div:nth-child(2)',

--- a/src/store/model/expert.ts
+++ b/src/store/model/expert.ts
@@ -11,8 +11,7 @@ export const Expert: Store = {
       },
     ],
     maxPrice: {
-      container: '.widget-Container-subContent .widget-ArticlePrice-price',
-      euroFormat: false,
+      container: '.widget-Container-subContent .widget-ArticlePrice-price'
     },
     outOfStock: [
       {

--- a/src/store/model/futurex.ts
+++ b/src/store/model/futurex.ts
@@ -8,8 +8,7 @@ export const Futurex: Store = {
       text: ['Auf Lager'],
     },
     maxPrice: {
-      container: '.price',
-      euroFormat: true,
+      container: '.price'
     },
     outOfStock: [
       {

--- a/src/store/model/galaxus.ts
+++ b/src/store/model/galaxus.ts
@@ -8,8 +8,7 @@ export const Galaxus: Store = {
       text: ['In den Warenkorb'],
     },
     maxPrice: {
-      container: '.productDetail .Z1c8',
-      euroFormat: true,
+      container: '.productDetail .Z1c8'
     },
     outOfStock: [
       {

--- a/src/store/model/game.ts
+++ b/src/store/model/game.ts
@@ -8,8 +8,7 @@ export const Game: Store = {
       text: ['Pre-order Now', 'Buy New'],
     },
     maxPrice: {
-      container: '.buyingOptions .btnPrice',
-      euroFormat: false,
+      container: '.buyingOptions .btnPrice'
     },
     outOfStock: {
       container: '.buyingOptions',

--- a/src/store/model/gamestop-de.ts
+++ b/src/store/model/gamestop-de.ts
@@ -14,8 +14,7 @@ export const GamestopDE: Store = {
       },
     ],
     maxPrice: {
-      container: '.buySection .prodPriceCont',
-      euroFormat: true,
+      container: '.buySection .prodPriceCont'
     },
     outOfStock: {
       container: '.megaButton',

--- a/src/store/model/gamestop-it.ts
+++ b/src/store/model/gamestop-it.ts
@@ -8,8 +8,7 @@ export const GamestopIT: Store = {
       text: ['Aggiungi al Carrello'],
     },
     maxPrice: {
-      container: '.buySection .prodPriceCont',
-      euroFormat: true,
+      container: '.buySection .prodPriceCont'
     },
     outOfStock: {
       container: '.megaButton .buyDisabled',

--- a/src/store/model/gamestop.ts
+++ b/src/store/model/gamestop.ts
@@ -14,8 +14,7 @@ export const Gamestop: Store = {
       },
     ],
     maxPrice: {
-      container: '.primary-details-row .actual-price',
-      euroFormat: false,
+      container: '.primary-details-row .actual-price'
     },
     outOfStock: {
       container: '.add-to-cart',

--- a/src/store/model/hardware-planet.ts
+++ b/src/store/model/hardware-planet.ts
@@ -10,8 +10,7 @@ export const HardwarePlanet: Store = {
       text: ['Aggiungi al carrello'],
     },
     maxPrice: {
-      container: '.product-price',
-      euroFormat: true,
+      container: '.product-price'
     },
     outOfStock: {
       container: '#product-availability',

--- a/src/store/model/harveynorman-ie.ts
+++ b/src/store/model/harveynorman-ie.ts
@@ -8,8 +8,7 @@ export const HarveyNormanIE: Store = {
       text: ['add to cart'],
     },
     maxPrice: {
-      container: '.price',
-      euroFormat: false,
+      container: '.price'
     },
     outOfStock: {
       container: '.product-highlight-text',

--- a/src/store/model/igame.ts
+++ b/src/store/model/igame.ts
@@ -10,8 +10,7 @@ export const Igamecomputer: Store = {
       text: ['ADD TO CART'],
     },
     maxPrice: {
-      container: 'div.price__pricing-group > div.price__regular > dd > span',
-      euroFormat: false,
+      container: 'div.price__pricing-group > div.price__regular > dd > span'
     },
     outOfStock: {
       container:

--- a/src/store/model/ldlc.ts
+++ b/src/store/model/ldlc.ts
@@ -8,8 +8,7 @@ export const Ldlc: Store = {
       text: ['stock'],
     },
     maxPrice: {
-      container: '.price .price',
-      euroFormat: true,
+      container: '.price .price'
     },
     outOfStock: {
       container: '.stock',

--- a/src/store/model/lmc.ts
+++ b/src/store/model/lmc.ts
@@ -9,8 +9,7 @@ export const LandmarkComputers: Store = {
       text: ['In Stock', 'Low In Stock', 'Stock in warehouse'],
     },
     maxPrice: {
-      container: '.product-views-price-lead',
-      euroFormat: false,
+      container: '.product-views-price-lead'
     },
     outOfStock: {
       container: '.stock-info-message',

--- a/src/store/model/mediamarkt.ts
+++ b/src/store/model/mediamarkt.ts
@@ -9,8 +9,7 @@ export const Mediamarkt: Store = {
       text: ['Das ging uns leider zu schnell.'],
     },
     maxPrice: {
-      container: 'span[font-family="price"]',
-      euroFormat: false,
+      container: 'span[font-family="price"]'
     },
     outOfStock: [
       {

--- a/src/store/model/medimax.ts
+++ b/src/store/model/medimax.ts
@@ -14,8 +14,7 @@ export const Medimax: Store = {
       },
     ],
     maxPrice: {
-      container: '.priceOfProduct',
-      euroFormat: true,
+      container: '.priceOfProduct'
     },
     outOfStock: {
       container: '.content .large',

--- a/src/store/model/megekko.ts
+++ b/src/store/model/megekko.ts
@@ -8,8 +8,7 @@ export const Megekko: Store = {
       text: ['dag', 'werkdag'],
     },
     maxPrice: {
-      container: '.col_right_container .euro',
-      euroFormat: false,
+      container: '.col_right_container .euro'
     },
     outOfStock: {
       container: '.product_detail .text_red',

--- a/src/store/model/memoryexpress.ts
+++ b/src/store/model/memoryexpress.ts
@@ -5,8 +5,7 @@ export const MemoryExpress: Store = {
   labels: {
     maxPrice: {
       container:
-        '#ProductPricing .GrandTotal.c-capr-pricing__grand-total > div',
-      euroFormat: false,
+        '#ProductPricing .GrandTotal.c-capr-pricing__grand-total > div'
     },
     outOfStock: {
       container:

--- a/src/store/model/microcenter.ts
+++ b/src/store/model/microcenter.ts
@@ -282,8 +282,7 @@ export const MicroCenter: Store = {
       text: ['in stock'],
     },
     maxPrice: {
-      container: 'span[id="pricing"]',
-      euroFormat: false,
+      container: 'span[id="pricing"]'
     },
   },
   links,

--- a/src/store/model/mindfactory.ts
+++ b/src/store/model/mindfactory.ts
@@ -8,8 +8,7 @@ export const Mindfactory: Store = {
       text: ['lagernd', 'verfügbar'],
     },
     maxPrice: {
-      container: 'div[class="pprice"]',
-      euroFormat: true,
+      container: 'div[class="pprice"]'
     },
     outOfStock: {
       container: '.pshipping',

--- a/src/store/model/msy.ts
+++ b/src/store/model/msy.ts
@@ -11,8 +11,7 @@ export const Msy: Store = {
     },
     maxPrice: {
       container:
-        '#product-details-form > div > div.product-essential > div.overview > div.prices > div > span',
-      euroFormat: false,
+        '#product-details-form > div > div.product-essential > div.overview > div.prices > div > span'
     },
     outOfStock: {
       container: 'td.spec-name:nth-child(2)',

--- a/src/store/model/mwave.ts
+++ b/src/store/model/mwave.ts
@@ -5,8 +5,7 @@ export const Mwave: Store = {
   currency: '$',
   labels: {
     maxPrice: {
-      container: 'div.divPriceNormal > div',
-      euroFormat: false,
+      container: 'div.divPriceNormal > div'
     },
     outOfStock: {
       container: '.stockAndDelivery > li:nth-child(1) > dl > dd',

--- a/src/store/model/newegg-ca.ts
+++ b/src/store/model/newegg-ca.ts
@@ -13,8 +13,7 @@ export const NeweggCa: Store = {
       text: ['add to cart'],
     },
     maxPrice: {
-      container: 'div#app div.product-price > ul > li.price-current > strong',
-      euroFormat: false,
+      container: 'div#app div.product-price > ul > li.price-current > strong'
     },
     outOfStock: [
       {

--- a/src/store/model/notebooksbilliger.ts
+++ b/src/store/model/notebooksbilliger.ts
@@ -13,8 +13,7 @@ export const Notebooksbilliger: Store = {
     },
     maxPrice: {
       container:
-        'form[name="cart_quantity"]  span[class*="product-price__regular"]',
-      euroFormat: true,
+        'form[name="cart_quantity"]  span[class*="product-price__regular"]'
     },
     outOfStock: [
       {

--- a/src/store/model/novatech.ts
+++ b/src/store/model/novatech.ts
@@ -9,8 +9,7 @@ export const Novatech: Store = {
       text: ['add to basket'],
     },
     maxPrice: {
-      container: 'p[class="newspec-price"]',
-      euroFormat: false, // Note: Novatech uses non-euroFromat as price seperator
+      container: 'p[class="newspec-price"]'
     },
     outOfStock: {
       container: '.newspec-pricesection',

--- a/src/store/model/novoatalho.ts
+++ b/src/store/model/novoatalho.ts
@@ -15,8 +15,7 @@ export const NovoAtalho: Store = {
     },
     maxPrice: {
       container:
-        'div.line > div.pull-right > div.text-right > span.product-price',
-      euroFormat: true,
+        'div.line > div.pull-right > div.text-right > span.product-price'
     },
   },
   links: [

--- a/src/store/model/officedepot.ts
+++ b/src/store/model/officedepot.ts
@@ -12,8 +12,7 @@ export const OfficeDepot: Store = {
       text: ['add to cart'],
     },
     maxPrice: {
-      container: 'span[class^="price_column right"]',
-      euroFormat: false,
+      container: 'span[class^="price_column right"]'
     },
   },
   links: [

--- a/src/store/model/ollo.ts
+++ b/src/store/model/ollo.ts
@@ -11,8 +11,7 @@ export const Ollo: Store = {
       },
     ],
     maxPrice: {
-      container: '.main-product-price',
-      euroFormat: true,
+      container: '.main-product-price'
     },
     outOfStock: {
       container:

--- a/src/store/model/otto.ts
+++ b/src/store/model/otto.ts
@@ -11,8 +11,7 @@ export const Otto: Store = {
       },
     ],
     maxPrice: {
-      container: '#normalPriceAmount',
-      euroFormat: true,
+      container: '#normalPriceAmount'
     },
     outOfStock: {
       container: 'div.p_message.p_message--hint > strong',

--- a/src/store/model/overclockers.ts
+++ b/src/store/model/overclockers.ts
@@ -9,8 +9,7 @@ export const Overclockers: Store = {
       text: ['add to basket', 'in stock'],
     },
     maxPrice: {
-      container: 'div[class="article_details_price"]',
-      euroFormat: false, // Note: Overclockers uses non-euroFromat as price seperator
+      container: 'div[class="article_details_price"]'
     },
     outOfStock: {
       container: '#detailbox',

--- a/src/store/model/pbtech.ts
+++ b/src/store/model/pbtech.ts
@@ -16,8 +16,7 @@ export const PBTech: Store = {
       },
     ],
     maxPrice: {
-      container: 'div.p_price_dd > div.p_price > span.ginc',
-      euroFormat: false,
+      container: 'div.p_price_dd > div.p_price > span.ginc'
     },
     outOfStock: {
       container:

--- a/src/store/model/pcbyte.ts
+++ b/src/store/model/pcbyte.ts
@@ -9,8 +9,7 @@ export const PCByte: Store = {
       text: ['in stock'],
     },
     maxPrice: {
-      container: 'div.price-line.d-flex.mb-3 > div:nth-child(1) > span > span',
-      euroFormat: false,
+      container: 'div.price-line.d-flex.mb-3 > div:nth-child(1) > span > span'
     },
     outOfStock: {
       container: 'a.btn:nth-child(3)',

--- a/src/store/model/pccomponentes.ts
+++ b/src/store/model/pccomponentes.ts
@@ -8,8 +8,7 @@ export const PCComponentes: Store = {
       text: ['Comprar'],
     },
     maxPrice: {
-      container: '#precio-main',
-      euroFormat: true,
+      container: '#precio-main'
     },
     outOfStock: {
       container: '#btnsWishAddBuy',

--- a/src/store/model/pcdiga.ts
+++ b/src/store/model/pcdiga.ts
@@ -12,8 +12,7 @@ export const PCDiga: Store = {
       text: ['Sem stock'],
     },
     maxPrice: {
-      container: '.price-container.price-final_price > .price-wrapper > span',
-      euroFormat: true,
+      container: '.price-container.price-final_price > .price-wrapper > span'
     },
   },
   links: [

--- a/src/store/model/pcking.ts
+++ b/src/store/model/pcking.ts
@@ -8,8 +8,7 @@ export const PCKing: Store = {
       text: ['sofort lieferbar [Versand]', 'abholbereit [PC-KING]'],
     },
     maxPrice: {
-      container: 'div.es_product_price-article_detail > b',
-      euroFormat: true,
+      container: 'div.es_product_price-article_detail > b'
     },
     outOfStock: [
       {

--- a/src/store/model/pny.ts
+++ b/src/store/model/pny.ts
@@ -8,8 +8,7 @@ export const Pny: Store = {
       text: ['add to cart'],
     },
     maxPrice: {
-      container: 'span[itemprop="price"]',
-      euroFormat: false,
+      container: 'span[itemprop="price"]'
     },
   },
   links: [

--- a/src/store/model/proshop-de.ts
+++ b/src/store/model/proshop-de.ts
@@ -9,8 +9,7 @@ export const ProshopDE: Store = {
     },
     maxPrice: {
       container:
-        '.site-currency-wrapper > span[class="site-currency-attention"]',
-      euroFormat: true,
+        '.site-currency-wrapper > span[class="site-currency-attention"]'
     },
     outOfStock: {
       container: '.site-currency-attention',

--- a/src/store/model/proshop-dk.ts
+++ b/src/store/model/proshop-dk.ts
@@ -9,8 +9,7 @@ export const ProshopDK: Store = {
     },
     maxPrice: {
       container:
-        '.site-currency-wrapper > span[class="site-currency-attention"]',
-      euroFormat: true,
+        '.site-currency-wrapper > span[class="site-currency-attention"]'
     },
     outOfStock: {
       container: '.site-stock',

--- a/src/store/model/rosman-melb.ts
+++ b/src/store/model/rosman-melb.ts
@@ -10,8 +10,7 @@ export const RosmanMelb: Store = {
       text: ['1', '2', '3', '4', '5', '6', '7', '8', '9'],
     },
     maxPrice: {
-      container: 'span.price.price--withTax.price--main',
-      euroFormat: false,
+      container: 'span.price.price--withTax.price--main'
     },
     outOfStock: {
       container:

--- a/src/store/model/rosman.ts
+++ b/src/store/model/rosman.ts
@@ -10,8 +10,7 @@ export const Rosman: Store = {
       text: ['1', '2', '3', '4', '5', '6', '7', '8', '9'],
     },
     maxPrice: {
-      container: 'span.price.price--withTax.price--main',
-      euroFormat: false,
+      container: 'span.price.price--withTax.price--main'
     },
     outOfStock: {
       container:

--- a/src/store/model/saturn.ts
+++ b/src/store/model/saturn.ts
@@ -9,8 +9,7 @@ export const Saturn: Store = {
       text: ['Das ging uns leider zu schnell.'],
     },
     maxPrice: {
-      container: 'span[font-family="price"]',
-      euroFormat: false,
+      container: 'span[font-family="price"]'
     },
     outOfStock: [
       {

--- a/src/store/model/saveonit.ts
+++ b/src/store/model/saveonit.ts
@@ -9,8 +9,7 @@ export const SaveOnIt: Store = {
       text: ['In Stock', '1', '2', '3', '4', '5', '6', '7', '8', '9'],
     },
     maxPrice: {
-      container: '.money',
-      euroFormat: false,
+      container: '.money'
     },
     outOfStock: {
       container: '.supplier',

--- a/src/store/model/scan.ts
+++ b/src/store/model/scan.ts
@@ -16,8 +16,7 @@ export const Scan: Store = {
       text: ['add to basket', 'in stock'],
     },
     maxPrice: {
-      container: '.buyPanel .price',
-      euroFormat: false, // Note: Scan uses non-euroFromat as price seperator
+      container: '.buyPanel .price'
     },
     outOfStock: {
       container: '.buyPanel .priceAvailability',

--- a/src/store/model/smythstoys-ie.ts
+++ b/src/store/model/smythstoys-ie.ts
@@ -9,8 +9,7 @@ export const SmythsToysIE: Store = {
       text: ['add to basket'],
     },
     maxPrice: {
-      container: '.price_tag',
-      euroFormat: false,
+      container: '.price_tag'
     },
     outOfStock: {
       container: '.instoreMessage',

--- a/src/store/model/smythstoys.ts
+++ b/src/store/model/smythstoys.ts
@@ -8,8 +8,7 @@ export const SmythsToys: Store = {
       text: ['add to basket'],
     },
     maxPrice: {
-      container: '.price_tag',
-      euroFormat: false,
+      container: '.price_tag'
     },
     outOfStock: {
       container: '.instoreMessage',

--- a/src/store/model/spielegrotte.ts
+++ b/src/store/model/spielegrotte.ts
@@ -12,8 +12,7 @@ export const Spielegrotte: Store = {
     ],
     maxPrice: {
       container:
-        'html > body > table > tbody > tr > td > div > table > tbody > tr > td > center > table > tbody > tr > td > font > b',
-      euroFormat: true,
+        'html > body > table > tbody > tr > td > div > table > tbody > tr > td > center > table > tbody > tr > td > font > b'
     },
     outOfStock: {
       container:

--- a/src/store/model/store.ts
+++ b/src/store/model/store.ts
@@ -7,7 +7,6 @@ export type Element = {
 
 export type Pricing = {
   container: string;
-  euroFormat?: boolean;
 };
 
 export type Brand =

--- a/src/store/model/storm.ts
+++ b/src/store/model/storm.ts
@@ -9,8 +9,7 @@ export const StormComputers: Store = {
       text: ['ADD TO CART'],
     },
     maxPrice: {
-      container: '.price',
-      euroFormat: false,
+      container: '.price'
     },
     outOfStock: {
       container: 'div.summary.entry-summary > p.stock.out-of-stock',

--- a/src/store/model/umart.ts
+++ b/src/store/model/umart.ts
@@ -9,8 +9,7 @@ export const Umart: Store = {
       text: ['in stock'],
     },
     maxPrice: {
-      container: '.goods-price',
-      euroFormat: false,
+      container: '.goods-price'
     },
     outOfStock: {
       container: 'div.price-box > div.stock-label',

--- a/src/store/model/very.ts
+++ b/src/store/model/very.ts
@@ -10,8 +10,7 @@ export const Very: Store = {
       text: ['available', 'low stock'],
     },
     maxPrice: {
-      container: '.priceNow',
-      euroFormat: false, // Note: Very uses non-euroFromat as price seperator
+      container: '.priceNow'
     },
     outOfStock: {
       container: '.stockMessaging .indicator',

--- a/src/store/model/vsgamers.ts
+++ b/src/store/model/vsgamers.ts
@@ -8,8 +8,7 @@ export const VsGamers: Store = {
       text: ['COMPRAR', 'RESERVAR'],
     },
     maxPrice: {
-      container: 'div[class="current ng-binding"]',
-      euroFormat: true,
+      container: 'div[class="current ng-binding"]'
     },
     outOfStock: {
       container: '#vs-product-sheet-dashboard',

--- a/src/store/model/wellstechnology.ts
+++ b/src/store/model/wellstechnology.ts
@@ -10,8 +10,7 @@ export const WellsTechnology: Store = {
       text: ['Buy it now'],
     },
     maxPrice: {
-      container: '#productPrice-product-template *',
-      euroFormat: false,
+      container: '#productPrice-product-template *'
     },
     outOfStock: {
       container: '#addToCartText-product-template',

--- a/src/store/model/wipoid.ts
+++ b/src/store/model/wipoid.ts
@@ -8,8 +8,7 @@ export const Wipoid: Store = {
       text: ['COMPRAR'],
     },
     maxPrice: {
-      container: '#our_price_display',
-      euroFormat: true,
+      container: '#our_price_display'
     },
     outOfStock: {
       container: '.buttons_bottom_block no-print',

--- a/src/store/model/zotac.ts
+++ b/src/store/model/zotac.ts
@@ -9,8 +9,7 @@ export const Zotac: Store = {
       text: ['add to cart'],
     },
     maxPrice: {
-      container: 'div[class="product-shop"] span[class="price"]',
-      euroFormat: false,
+      container: 'div[class="product-shop"] span[class="price"]'
     },
   },
   links: [


### PR DESCRIPTION
### Description

   remove useless parameter euroformat and replace it with autodetection by Regex
   fixes issue with european stores using dot notation for pricing

### Testing
   Tested on : 
        LDLC.com
        rueducommmerce.fr
        topachat.com
        amazon.fr
        newegg.com

