### PR TITLE
refactor(store): replace euroFormat with regex

### DIFF
--- a/src/store/includes-labels.ts
+++ b/src/store/includes-labels.ts
@@ -125,9 +125,8 @@ export async function getPrice(
   const priceString = await extractPageContents(page, selector);
 
   if (priceString) {
-    const priceSeparator = query.euroFormat ? /\./g : /,/g;
     const price = Number.parseFloat(
-      priceString.replace(priceSeparator, '').match(/\d+/g)!.join('.')
+      priceString.replace(/\\.|\\,/g, '').match(/\d+/g)!.join('.') // eslint-disable-line
     );
 
     logger.debug('received price', price);

--- a/src/store/model/acompc.ts
+++ b/src/store/model/acompc.ts
@@ -9,7 +9,6 @@ export const AComPC: Store = {
     },
     maxPrice: {
       container: '.price',
-      euroFormat: true,
     },
     outOfStock: [
       {

--- a/src/store/model/adorama.ts
+++ b/src/store/model/adorama.ts
@@ -13,7 +13,6 @@ export const Adorama: Store = {
     },
     maxPrice: {
       container: '.your-price',
-      euroFormat: false,
     },
   },
   links: [

--- a/src/store/model/akinformatica.ts
+++ b/src/store/model/akinformatica.ts
@@ -15,7 +15,6 @@ export const Akinformatica: Store = {
     ],
     maxPrice: {
       container: '#PrezzoListinoIvatoLabel',
-      euroFormat: true,
     },
     outOfStock: [
       {

--- a/src/store/model/allneeds.ts
+++ b/src/store/model/allneeds.ts
@@ -10,7 +10,6 @@ export const Allneeds: Store = {
     },
     maxPrice: {
       container: 'span.price',
-      euroFormat: false,
     },
     outOfStock: {
       container: '.amstockstatus',

--- a/src/store/model/alternate-nl.ts
+++ b/src/store/model/alternate-nl.ts
@@ -9,7 +9,6 @@ export const AlternateNL: Store = {
     },
     maxPrice: {
       container: 'div.price > span',
-      euroFormat: true,
     },
     outOfStock: {
       container: '.stockStatus',

--- a/src/store/model/alternate.ts
+++ b/src/store/model/alternate.ts
@@ -14,7 +14,6 @@ export const Alternate: Store = {
     },
     maxPrice: {
       container: 'div.price > span',
-      euroFormat: true,
     },
     outOfStock: [
       {

--- a/src/store/model/amazon-de-warehouse.ts
+++ b/src/store/model/amazon-de-warehouse.ts
@@ -17,7 +17,6 @@ export const AmazonDeWarehouse: Store = {
     },
     maxPrice: {
       container: '.olpOfferPrice',
-      euroFormat: true,
     },
     outOfStock: [
       {

--- a/src/store/model/amazon-de.ts
+++ b/src/store/model/amazon-de.ts
@@ -17,7 +17,6 @@ export const AmazonDe: Store = {
     },
     maxPrice: {
       container: '#priceblock_ourprice',
-      euroFormat: true,
     },
     outOfStock: [
       {

--- a/src/store/model/amazon-fr.ts
+++ b/src/store/model/amazon-fr.ts
@@ -14,7 +14,6 @@ export const AmazonFr: Store = {
     },
     maxPrice: {
       container: '#priceblock_ourprice',
-      euroFormat: true,
     },
     outOfStock: [
       {

--- a/src/store/model/amazon-it.ts
+++ b/src/store/model/amazon-it.ts
@@ -14,7 +14,6 @@ export const AmazonIt: Store = {
     },
     maxPrice: {
       container: '#priceblock_ourprice',
-      euroFormat: true,
     },
   },
   links: [

--- a/src/store/model/amazon-nl.ts
+++ b/src/store/model/amazon-nl.ts
@@ -19,7 +19,6 @@ export const AmazonNl: Store = {
     ],
     maxPrice: {
       container: '#priceblock_ourprice',
-      euroFormat: true,
     },
     outOfStock: [
       {

--- a/src/store/model/amd-ca.ts
+++ b/src/store/model/amd-ca.ts
@@ -9,7 +9,6 @@ export const AmdCa: Store = {
     },
     maxPrice: {
       container: '.product-page-description h4',
-      euroFormat: false,
     },
   },
   links: [

--- a/src/store/model/amd-de.ts
+++ b/src/store/model/amd-de.ts
@@ -9,7 +9,6 @@ export const AmdDe: Store = {
     },
     maxPrice: {
       container: '.product-page-description h4',
-      euroFormat: true,
     },
     outOfStock: {
       container: '.btn-radeon',

--- a/src/store/model/amd-it.ts
+++ b/src/store/model/amd-it.ts
@@ -9,7 +9,6 @@ export const AmdIt: Store = {
     },
     maxPrice: {
       container: '.product-page-description h4',
-      euroFormat: true,
     },
   },
   links: [

--- a/src/store/model/amd-uk.ts
+++ b/src/store/model/amd-uk.ts
@@ -15,7 +15,6 @@ export const AmdUk: Store = {
     ],
     maxPrice: {
       container: '.product-page-description h4',
-      euroFormat: false,
     },
     outOfStock: [
       {

--- a/src/store/model/amd.ts
+++ b/src/store/model/amd.ts
@@ -9,7 +9,6 @@ export const Amd: Store = {
     },
     maxPrice: {
       container: '.product-page-description h4',
-      euroFormat: false,
     },
   },
   links: [

--- a/src/store/model/antonline.ts
+++ b/src/store/model/antonline.ts
@@ -9,7 +9,6 @@ export const AntOnline: Store = {
     },
     maxPrice: {
       container: '.cPrice',
-      euroFormat: false,
     },
     outOfStock: {
       container: '.priceView-price .priceView-hero-price span',

--- a/src/store/model/aria.ts
+++ b/src/store/model/aria.ts
@@ -10,7 +10,6 @@ export const Aria: Store = {
     },
     maxPrice: {
       container: '.priceBig',
-      euroFormat: false, // Note: Aria uses non-euroFromat as price seperator
     },
     outOfStock: {
       container: '.fBox',

--- a/src/store/model/arlt.ts
+++ b/src/store/model/arlt.ts
@@ -9,7 +9,6 @@ export const Arlt: Store = {
     },
     maxPrice: {
       container: '.articleprice .price',
-      euroFormat: true,
     },
     outOfStock: {
       container: '.articleDesc .shippingtext',

--- a/src/store/model/awd.ts
+++ b/src/store/model/awd.ts
@@ -10,7 +10,6 @@ export const Awd: Store = {
     },
     maxPrice: {
       container: '.ty-price',
-      euroFormat: false, // Note: Awd uses non-euroFromat as price seperator
     },
     outOfStock: {
       container: '.vs-stock.ty-float-left',

--- a/src/store/model/azerty.ts
+++ b/src/store/model/azerty.ts
@@ -9,7 +9,6 @@ export const Azerty: Store = {
     },
     maxPrice: {
       container: '.mod_article .price',
-      euroFormat: true,
     },
     outOfStock: {
       container: '.orderdelay',

--- a/src/store/model/bandh.ts
+++ b/src/store/model/bandh.ts
@@ -10,7 +10,6 @@ export const BAndH: Store = {
     },
     maxPrice: {
       container: 'div[data-selenium="pricingPrice"]',
-      euroFormat: false,
     },
     outOfStock: {
       container: 'button[data-selenium="notifyAvailabilityButton"]',

--- a/src/store/model/bestbuy-ca.ts
+++ b/src/store/model/bestbuy-ca.ts
@@ -5,7 +5,6 @@ export const BestBuyCa: Store = {
   labels: {
     maxPrice: {
       container: 'div[class*="pricingContainer"]',
-      euroFormat: false,
     },
     outOfStock: {
       container: '.addToCartButton:disabled',

--- a/src/store/model/box.ts
+++ b/src/store/model/box.ts
@@ -11,7 +11,6 @@ export const Box: Store = {
     },
     maxPrice: {
       container: '.p-price',
-      euroFormat: false, // Note: Box uses non-euroFromat as price seperator
     },
     outOfStock: {
       container: '#divBuyButton',

--- a/src/store/model/bpctech.ts
+++ b/src/store/model/bpctech.ts
@@ -10,7 +10,6 @@ export const Bpctech: Store = {
     },
     maxPrice: {
       container: 'div.price-box.price-final_price > span > span',
-      euroFormat: false,
     },
   },
   links: [

--- a/src/store/model/bpmpower.ts
+++ b/src/store/model/bpmpower.ts
@@ -9,7 +9,6 @@ export const BpmPower: Store = {
     },
     maxPrice: {
       container: 'p.prezzoScheda:nth-child(1)',
-      euroFormat: true,
     },
     outOfStock: {
       container: '.dispoSiProd >span',

--- a/src/store/model/canadacomputers.ts
+++ b/src/store/model/canadacomputers.ts
@@ -9,7 +9,6 @@ export const CanadaComputers: Store = {
     },
     maxPrice: {
       container: '.h2-big > strong:nth-child(1)',
-      euroFormat: false,
     },
   },
   links: [

--- a/src/store/model/caseking.ts
+++ b/src/store/model/caseking.ts
@@ -10,7 +10,6 @@ export const Caseking: Store = {
     },
     maxPrice: {
       container: '#buybox .article_details_price',
-      euroFormat: true,
     },
     outOfStock: {
       container: '.delivery_container',

--- a/src/store/model/ccl.ts
+++ b/src/store/model/ccl.ts
@@ -11,7 +11,6 @@ export const Ccl: Store = {
     },
     maxPrice: {
       container: '#pnlPriceText > p',
-      euroFormat: false, // Note: CCL uses non-euroFromat as price seperator
     },
     outOfStock: {
       container: '#pnlSoldOut',

--- a/src/store/model/centrecom.ts
+++ b/src/store/model/centrecom.ts
@@ -10,7 +10,6 @@ export const Centrecom: Store = {
     },
     maxPrice: {
       container: 'div.prod_price_current.product-price > span',
-      euroFormat: false,
     },
     outOfStock: {
       container: '.prod_stores_stock > li:nth-child(1) > span:nth-child(2)',

--- a/src/store/model/computeralliance.ts
+++ b/src/store/model/computeralliance.ts
@@ -11,7 +11,6 @@ export const ComputerAlliance: Store = {
     },
     maxPrice: {
       container: 'span.price',
-      euroFormat: false,
     },
     outOfStock: {
       container:

--- a/src/store/model/computeruniverse.ts
+++ b/src/store/model/computeruniverse.ts
@@ -13,7 +13,6 @@ export const Computeruniverse: Store = {
     },
     maxPrice: {
       container: '.product-price',
-      euroFormat: true,
     },
     outOfStock: {
       container: '.availability',

--- a/src/store/model/coolblue.ts
+++ b/src/store/model/coolblue.ts
@@ -9,7 +9,6 @@ export const Coolblue: Store = {
     },
     maxPrice: {
       container: '.js-order-block .sales-price__current',
-      euroFormat: true,
     },
     outOfStock: {
       container: '.product-order',

--- a/src/store/model/coolmod.ts
+++ b/src/store/model/coolmod.ts
@@ -9,7 +9,6 @@ export const Coolmod: Store = {
     },
     maxPrice: {
       container: '.text-price-total',
-      euroFormat: true,
     },
     outOfStock: {
       container: '.product-availability',

--- a/src/store/model/corsair.ts
+++ b/src/store/model/corsair.ts
@@ -9,7 +9,6 @@ export const Corsair: Store = {
     },
     maxPrice: {
       container: '.product-price',
-      euroFormat: false,
     },
   },
   links: [

--- a/src/store/model/currys.ts
+++ b/src/store/model/currys.ts
@@ -10,7 +10,6 @@ export const Currys: Store = {
     },
     maxPrice: {
       container: '#product-actions span[class*="ProductPriceBlock__Price"]',
-      euroFormat: false, // Note: Currys uses non-euroFromat as price seperator
     },
     outOfStock: {
       container: '#product-actions .unavailable',

--- a/src/store/model/cyberport.ts
+++ b/src/store/model/cyberport.ts
@@ -9,7 +9,6 @@ export const Cyberport: Store = {
     },
     maxPrice: {
       container: '#productDetailOverview .price',
-      euroFormat: true,
     },
     outOfStock: {
       container: '.tooltipAvailabilityParent',

--- a/src/store/model/dcomp.ts
+++ b/src/store/model/dcomp.ts
@@ -10,7 +10,6 @@ export const Dcomp: Store = {
     },
     maxPrice: {
       container: '#prodprice',
-      euroFormat: false,
     },
     outOfStock: {
       container: '#cart-info > button.btn.notifyMe',

--- a/src/store/model/drako.ts
+++ b/src/store/model/drako.ts
@@ -11,7 +11,6 @@ export const Drako: Store = {
     ],
     maxPrice: {
       container: '.price',
-      euroFormat: true,
     },
   },
   links: [

--- a/src/store/model/ebuyer.ts
+++ b/src/store/model/ebuyer.ts
@@ -10,7 +10,6 @@ export const Ebuyer: Store = {
     },
     maxPrice: {
       container: '.purchase-info__price .price',
-      euroFormat: false, // Note: ebuyer uses non-euroFromat as price seperator
     },
     outOfStock: {
       container: '.purchase-info',

--- a/src/store/model/elcorteingles.ts
+++ b/src/store/model/elcorteingles.ts
@@ -19,7 +19,6 @@ export const Elcorteingles: Store = {
     ],
     maxPrice: {
       container: '.product_detail-buy-price-container .price._big',
-      euroFormat: true,
     },
     outOfStock: [
       {

--- a/src/store/model/eprice.ts
+++ b/src/store/model/eprice.ts
@@ -9,7 +9,6 @@ export const Eprice: Store = {
     },
     maxPrice: {
       container: '#PrezzoClasic span[class*="big"]',
-      euroFormat: true,
     },
     outOfStock: {
       container: '.dispo',

--- a/src/store/model/equippr.ts
+++ b/src/store/model/equippr.ts
@@ -9,7 +9,6 @@ export const Equippr: Store = {
     },
     maxPrice: {
       container: '.product--price',
-      euroFormat: true,
     },
     outOfStock: {
       container: '.product--buybox',

--- a/src/store/model/euronics-de.ts
+++ b/src/store/model/euronics-de.ts
@@ -9,7 +9,6 @@ export const EuronicsDE: Store = {
     },
     maxPrice: {
       container: '.price--content',
-      euroFormat: true,
     },
     outOfStock: {
       container:

--- a/src/store/model/evatech.ts
+++ b/src/store/model/evatech.ts
@@ -10,7 +10,6 @@ export const Evatech: Store = {
     },
     maxPrice: {
       container: '.product_detail_price',
-      euroFormat: false,
     },
     outOfStock: {
       container: '.product_detail_add_to_cart > div:nth-child(2)',

--- a/src/store/model/expert.ts
+++ b/src/store/model/expert.ts
@@ -12,7 +12,6 @@ export const Expert: Store = {
     ],
     maxPrice: {
       container: '.widget-Container-subContent .widget-ArticlePrice-price',
-      euroFormat: false,
     },
     outOfStock: [
       {

--- a/src/store/model/futurex.ts
+++ b/src/store/model/futurex.ts
@@ -9,7 +9,6 @@ export const Futurex: Store = {
     },
     maxPrice: {
       container: '.price',
-      euroFormat: true,
     },
     outOfStock: [
       {

--- a/src/store/model/galaxus.ts
+++ b/src/store/model/galaxus.ts
@@ -9,7 +9,6 @@ export const Galaxus: Store = {
     },
     maxPrice: {
       container: '.productDetail .Z1c8',
-      euroFormat: true,
     },
     outOfStock: [
       {

--- a/src/store/model/game.ts
+++ b/src/store/model/game.ts
@@ -9,7 +9,6 @@ export const Game: Store = {
     },
     maxPrice: {
       container: '.buyingOptions .btnPrice',
-      euroFormat: false,
     },
     outOfStock: {
       container: '.buyingOptions',

--- a/src/store/model/gamestop-de.ts
+++ b/src/store/model/gamestop-de.ts
@@ -15,7 +15,6 @@ export const GamestopDE: Store = {
     ],
     maxPrice: {
       container: '.buySection .prodPriceCont',
-      euroFormat: true,
     },
     outOfStock: {
       container: '.megaButton',

--- a/src/store/model/gamestop-it.ts
+++ b/src/store/model/gamestop-it.ts
@@ -9,7 +9,6 @@ export const GamestopIT: Store = {
     },
     maxPrice: {
       container: '.buySection .prodPriceCont',
-      euroFormat: true,
     },
     outOfStock: {
       container: '.megaButton .buyDisabled',

--- a/src/store/model/gamestop.ts
+++ b/src/store/model/gamestop.ts
@@ -15,7 +15,6 @@ export const Gamestop: Store = {
     ],
     maxPrice: {
       container: '.primary-details-row .actual-price',
-      euroFormat: false,
     },
     outOfStock: {
       container: '.add-to-cart',

--- a/src/store/model/hardware-planet.ts
+++ b/src/store/model/hardware-planet.ts
@@ -11,7 +11,6 @@ export const HardwarePlanet: Store = {
     },
     maxPrice: {
       container: '.product-price',
-      euroFormat: true,
     },
     outOfStock: {
       container: '#product-availability',

--- a/src/store/model/harveynorman-ie.ts
+++ b/src/store/model/harveynorman-ie.ts
@@ -9,7 +9,6 @@ export const HarveyNormanIE: Store = {
     },
     maxPrice: {
       container: '.price',
-      euroFormat: false,
     },
     outOfStock: {
       container: '.product-highlight-text',

--- a/src/store/model/igame.ts
+++ b/src/store/model/igame.ts
@@ -11,7 +11,6 @@ export const Igamecomputer: Store = {
     },
     maxPrice: {
       container: 'div.price__pricing-group > div.price__regular > dd > span',
-      euroFormat: false,
     },
     outOfStock: {
       container:

--- a/src/store/model/ldlc.ts
+++ b/src/store/model/ldlc.ts
@@ -9,7 +9,6 @@ export const Ldlc: Store = {
     },
     maxPrice: {
       container: '.price .price',
-      euroFormat: true,
     },
     outOfStock: {
       container: '.stock',

--- a/src/store/model/lmc.ts
+++ b/src/store/model/lmc.ts
@@ -10,7 +10,6 @@ export const LandmarkComputers: Store = {
     },
     maxPrice: {
       container: '.product-views-price-lead',
-      euroFormat: false,
     },
     outOfStock: {
       container: '.stock-info-message',

--- a/src/store/model/mediamarkt.ts
+++ b/src/store/model/mediamarkt.ts
@@ -10,7 +10,6 @@ export const Mediamarkt: Store = {
     },
     maxPrice: {
       container: 'span[font-family="price"]',
-      euroFormat: false,
     },
     outOfStock: [
       {

--- a/src/store/model/medimax.ts
+++ b/src/store/model/medimax.ts
@@ -15,7 +15,6 @@ export const Medimax: Store = {
     ],
     maxPrice: {
       container: '.priceOfProduct',
-      euroFormat: true,
     },
     outOfStock: {
       container: '.content .large',

--- a/src/store/model/megekko.ts
+++ b/src/store/model/megekko.ts
@@ -9,7 +9,6 @@ export const Megekko: Store = {
     },
     maxPrice: {
       container: '.col_right_container .euro',
-      euroFormat: false,
     },
     outOfStock: {
       container: '.product_detail .text_red',

--- a/src/store/model/memoryexpress.ts
+++ b/src/store/model/memoryexpress.ts
@@ -6,7 +6,6 @@ export const MemoryExpress: Store = {
     maxPrice: {
       container:
         '#ProductPricing .GrandTotal.c-capr-pricing__grand-total > div',
-      euroFormat: false,
     },
     outOfStock: {
       container:

--- a/src/store/model/microcenter.ts
+++ b/src/store/model/microcenter.ts
@@ -283,7 +283,6 @@ export const MicroCenter: Store = {
     },
     maxPrice: {
       container: 'span[id="pricing"]',
-      euroFormat: false,
     },
   },
   links,

--- a/src/store/model/mindfactory.ts
+++ b/src/store/model/mindfactory.ts
@@ -9,7 +9,6 @@ export const Mindfactory: Store = {
     },
     maxPrice: {
       container: 'div[class="pprice"]',
-      euroFormat: true,
     },
     outOfStock: {
       container: '.pshipping',

--- a/src/store/model/msy.ts
+++ b/src/store/model/msy.ts
@@ -12,7 +12,6 @@ export const Msy: Store = {
     maxPrice: {
       container:
         '#product-details-form > div > div.product-essential > div.overview > div.prices > div > span',
-      euroFormat: false,
     },
     outOfStock: {
       container: 'td.spec-name:nth-child(2)',

--- a/src/store/model/mwave.ts
+++ b/src/store/model/mwave.ts
@@ -6,7 +6,6 @@ export const Mwave: Store = {
   labels: {
     maxPrice: {
       container: 'div.divPriceNormal > div',
-      euroFormat: false,
     },
     outOfStock: {
       container: '.stockAndDelivery > li:nth-child(1) > dl > dd',

--- a/src/store/model/newegg-ca.ts
+++ b/src/store/model/newegg-ca.ts
@@ -14,7 +14,6 @@ export const NeweggCa: Store = {
     },
     maxPrice: {
       container: 'div#app div.product-price > ul > li.price-current > strong',
-      euroFormat: false,
     },
     outOfStock: [
       {

--- a/src/store/model/notebooksbilliger.ts
+++ b/src/store/model/notebooksbilliger.ts
@@ -14,7 +14,6 @@ export const Notebooksbilliger: Store = {
     maxPrice: {
       container:
         'form[name="cart_quantity"]  span[class*="product-price__regular"]',
-      euroFormat: true,
     },
     outOfStock: [
       {

--- a/src/store/model/novatech.ts
+++ b/src/store/model/novatech.ts
@@ -10,7 +10,6 @@ export const Novatech: Store = {
     },
     maxPrice: {
       container: 'p[class="newspec-price"]',
-      euroFormat: false, // Note: Novatech uses non-euroFromat as price seperator
     },
     outOfStock: {
       container: '.newspec-pricesection',

--- a/src/store/model/novoatalho.ts
+++ b/src/store/model/novoatalho.ts
@@ -16,7 +16,6 @@ export const NovoAtalho: Store = {
     maxPrice: {
       container:
         'div.line > div.pull-right > div.text-right > span.product-price',
-      euroFormat: true,
     },
   },
   links: [

--- a/src/store/model/officedepot.ts
+++ b/src/store/model/officedepot.ts
@@ -13,7 +13,6 @@ export const OfficeDepot: Store = {
     },
     maxPrice: {
       container: 'span[class^="price_column right"]',
-      euroFormat: false,
     },
   },
   links: [

--- a/src/store/model/ollo.ts
+++ b/src/store/model/ollo.ts
@@ -12,7 +12,6 @@ export const Ollo: Store = {
     ],
     maxPrice: {
       container: '.main-product-price',
-      euroFormat: true,
     },
     outOfStock: {
       container:

--- a/src/store/model/otto.ts
+++ b/src/store/model/otto.ts
@@ -12,7 +12,6 @@ export const Otto: Store = {
     ],
     maxPrice: {
       container: '#normalPriceAmount',
-      euroFormat: true,
     },
     outOfStock: {
       container: 'div.p_message.p_message--hint > strong',

--- a/src/store/model/overclockers.ts
+++ b/src/store/model/overclockers.ts
@@ -10,7 +10,6 @@ export const Overclockers: Store = {
     },
     maxPrice: {
       container: 'div[class="article_details_price"]',
-      euroFormat: false, // Note: Overclockers uses non-euroFromat as price seperator
     },
     outOfStock: {
       container: '#detailbox',

--- a/src/store/model/pbtech.ts
+++ b/src/store/model/pbtech.ts
@@ -17,7 +17,6 @@ export const PBTech: Store = {
     ],
     maxPrice: {
       container: 'div.p_price_dd > div.p_price > span.ginc',
-      euroFormat: false,
     },
     outOfStock: {
       container:

--- a/src/store/model/pcbyte.ts
+++ b/src/store/model/pcbyte.ts
@@ -10,7 +10,6 @@ export const PCByte: Store = {
     },
     maxPrice: {
       container: 'div.price-line.d-flex.mb-3 > div:nth-child(1) > span > span',
-      euroFormat: false,
     },
     outOfStock: {
       container: 'a.btn:nth-child(3)',

--- a/src/store/model/pccomponentes.ts
+++ b/src/store/model/pccomponentes.ts
@@ -9,7 +9,6 @@ export const PCComponentes: Store = {
     },
     maxPrice: {
       container: '#precio-main',
-      euroFormat: true,
     },
     outOfStock: {
       container: '#btnsWishAddBuy',

--- a/src/store/model/pcdiga.ts
+++ b/src/store/model/pcdiga.ts
@@ -13,7 +13,6 @@ export const PCDiga: Store = {
     },
     maxPrice: {
       container: '.price-container.price-final_price > .price-wrapper > span',
-      euroFormat: true,
     },
   },
   links: [

--- a/src/store/model/pcking.ts
+++ b/src/store/model/pcking.ts
@@ -9,7 +9,6 @@ export const PCKing: Store = {
     },
     maxPrice: {
       container: 'div.es_product_price-article_detail > b',
-      euroFormat: true,
     },
     outOfStock: [
       {

--- a/src/store/model/pny.ts
+++ b/src/store/model/pny.ts
@@ -9,7 +9,6 @@ export const Pny: Store = {
     },
     maxPrice: {
       container: 'span[itemprop="price"]',
-      euroFormat: false,
     },
   },
   links: [

--- a/src/store/model/proshop-de.ts
+++ b/src/store/model/proshop-de.ts
@@ -10,7 +10,6 @@ export const ProshopDE: Store = {
     maxPrice: {
       container:
         '.site-currency-wrapper > span[class="site-currency-attention"]',
-      euroFormat: true,
     },
     outOfStock: {
       container: '.site-currency-attention',

--- a/src/store/model/proshop-dk.ts
+++ b/src/store/model/proshop-dk.ts
@@ -10,7 +10,6 @@ export const ProshopDK: Store = {
     maxPrice: {
       container:
         '.site-currency-wrapper > span[class="site-currency-attention"]',
-      euroFormat: true,
     },
     outOfStock: {
       container: '.site-stock',

--- a/src/store/model/rosman-melb.ts
+++ b/src/store/model/rosman-melb.ts
@@ -11,7 +11,6 @@ export const RosmanMelb: Store = {
     },
     maxPrice: {
       container: 'span.price.price--withTax.price--main',
-      euroFormat: false,
     },
     outOfStock: {
       container:

--- a/src/store/model/rosman.ts
+++ b/src/store/model/rosman.ts
@@ -11,7 +11,6 @@ export const Rosman: Store = {
     },
     maxPrice: {
       container: 'span.price.price--withTax.price--main',
-      euroFormat: false,
     },
     outOfStock: {
       container:

--- a/src/store/model/saturn.ts
+++ b/src/store/model/saturn.ts
@@ -10,7 +10,6 @@ export const Saturn: Store = {
     },
     maxPrice: {
       container: 'span[font-family="price"]',
-      euroFormat: false,
     },
     outOfStock: [
       {

--- a/src/store/model/saveonit.ts
+++ b/src/store/model/saveonit.ts
@@ -10,7 +10,6 @@ export const SaveOnIt: Store = {
     },
     maxPrice: {
       container: '.money',
-      euroFormat: false,
     },
     outOfStock: {
       container: '.supplier',

--- a/src/store/model/scan.ts
+++ b/src/store/model/scan.ts
@@ -17,7 +17,6 @@ export const Scan: Store = {
     },
     maxPrice: {
       container: '.buyPanel .price',
-      euroFormat: false, // Note: Scan uses non-euroFromat as price seperator
     },
     outOfStock: {
       container: '.buyPanel .priceAvailability',

--- a/src/store/model/smythstoys-ie.ts
+++ b/src/store/model/smythstoys-ie.ts
@@ -10,7 +10,6 @@ export const SmythsToysIE: Store = {
     },
     maxPrice: {
       container: '.price_tag',
-      euroFormat: false,
     },
     outOfStock: {
       container: '.instoreMessage',

--- a/src/store/model/smythstoys.ts
+++ b/src/store/model/smythstoys.ts
@@ -9,7 +9,6 @@ export const SmythsToys: Store = {
     },
     maxPrice: {
       container: '.price_tag',
-      euroFormat: false,
     },
     outOfStock: {
       container: '.instoreMessage',

--- a/src/store/model/spielegrotte.ts
+++ b/src/store/model/spielegrotte.ts
@@ -13,7 +13,6 @@ export const Spielegrotte: Store = {
     maxPrice: {
       container:
         'html > body > table > tbody > tr > td > div > table > tbody > tr > td > center > table > tbody > tr > td > font > b',
-      euroFormat: true,
     },
     outOfStock: {
       container:

--- a/src/store/model/store.ts
+++ b/src/store/model/store.ts
@@ -7,7 +7,6 @@ export type Element = {
 
 export type Pricing = {
   container: string;
-  euroFormat?: boolean;
 };
 
 export type Brand =

--- a/src/store/model/storm.ts
+++ b/src/store/model/storm.ts
@@ -10,7 +10,6 @@ export const StormComputers: Store = {
     },
     maxPrice: {
       container: '.price',
-      euroFormat: false,
     },
     outOfStock: {
       container: 'div.summary.entry-summary > p.stock.out-of-stock',

--- a/src/store/model/umart.ts
+++ b/src/store/model/umart.ts
@@ -10,7 +10,6 @@ export const Umart: Store = {
     },
     maxPrice: {
       container: '.goods-price',
-      euroFormat: false,
     },
     outOfStock: {
       container: 'div.price-box > div.stock-label',

--- a/src/store/model/very.ts
+++ b/src/store/model/very.ts
@@ -11,7 +11,6 @@ export const Very: Store = {
     },
     maxPrice: {
       container: '.priceNow',
-      euroFormat: false, // Note: Very uses non-euroFromat as price seperator
     },
     outOfStock: {
       container: '.stockMessaging .indicator',

--- a/src/store/model/vsgamers.ts
+++ b/src/store/model/vsgamers.ts
@@ -9,7 +9,6 @@ export const VsGamers: Store = {
     },
     maxPrice: {
       container: 'div[class="current ng-binding"]',
-      euroFormat: true,
     },
     outOfStock: {
       container: '#vs-product-sheet-dashboard',

--- a/src/store/model/wellstechnology.ts
+++ b/src/store/model/wellstechnology.ts
@@ -11,7 +11,6 @@ export const WellsTechnology: Store = {
     },
     maxPrice: {
       container: '#productPrice-product-template *',
-      euroFormat: false,
     },
     outOfStock: {
       container: '#addToCartText-product-template',

--- a/src/store/model/wipoid.ts
+++ b/src/store/model/wipoid.ts
@@ -9,7 +9,6 @@ export const Wipoid: Store = {
     },
     maxPrice: {
       container: '#our_price_display',
-      euroFormat: true,
     },
     outOfStock: {
       container: '.buttons_bottom_block no-print',

--- a/src/store/model/zotac.ts
+++ b/src/store/model/zotac.ts
@@ -10,7 +10,6 @@ export const Zotac: Store = {
     },
     maxPrice: {
       container: 'div[class="product-shop"] span[class="price"]',
-      euroFormat: false,
     },
   },
   links: [


### PR DESCRIPTION
### Description

   remove useless parameter euroformat and replace it with autodetection by Regex
   fixes issue with european stores using dot notation for pricing

### Testing
   Tested on : 
        LDLC.com
        rueducommmerce.fr
        topachat.com
        amazon.fr
        newegg.com