### PR TITLE
fix: parsing prices with thousands separator and European format

### DIFF
--- a/src/store/includes-labels.ts
+++ b/src/store/includes-labels.ts
@@ -116,16 +116,6 @@ export function includesLabels(
   );
 }
 
-function getPriceFromString(priceString: string, euroFormat: boolean): number {
-  return Number.parseFloat(
-    priceString
-      .replace(/\\/g, '')
-      .replace(euroFormat ? /\./g : /,/g, '')
-      .match(/\d+/g)!
-      .join('.')
-  );
-}
-
 export async function getPrice(
   page: Page,
   query: Pricing,
@@ -135,12 +125,16 @@ export async function getPrice(
   const priceString = await extractPageContents(page, selector);
 
   if (priceString) {
-    const euroFormat = priceString.indexOf('.') < priceString.indexOf(',');
-    let price = getPriceFromString(priceString, euroFormat);
-    //Sanity check, flip "euroFormat" if price lower than 50
-    if (price < 50) {
-      price = Math.max(price, getPriceFromString(priceString, !euroFormat));
-    }
+    const thousandsSeparator =
+      priceString.search(/\d+\.\d{3}|\d+,\d{2}$/) > -1 ? /\./g : /,/g;
+    const price = Number.parseFloat(
+      priceString
+        .replace(/\\/g, '')
+        .replace(thousandsSeparator, '')
+        .match(/\d+/g)!
+        .join('.')
+    );
+
     logger.debug('received price', price);
     return price;
   }

--- a/src/store/includes-labels.ts
+++ b/src/store/includes-labels.ts
@@ -116,6 +116,16 @@ export function includesLabels(
   );
 }
 
+function getPriceFromString(priceString: string, euroFormat: boolean): number {
+  return Number.parseFloat(
+    priceString
+      .replace(/\\/g, '')
+      .replace(euroFormat ? /\./g : /,/g, '')
+      .match(/\d+/g)!
+      .join('.')
+  );
+}
+
 export async function getPrice(
   page: Page,
   query: Pricing,
@@ -126,13 +136,11 @@ export async function getPrice(
 
   if (priceString) {
     const euroFormat = priceString.indexOf('.') < priceString.indexOf(',');
-    const price = Number.parseFloat(
-      priceString
-        .replace(/\\/g, '')
-        .replace(euroFormat ? /\./g : /,/g, '')
-        .match(/\d+/g)!
-        .join('.')
-    );
+    let price = getPriceFromString(priceString, euroFormat);
+    //Sanity check, flip "euroFormat" if price lower than 50
+    if (price < 50) {
+      price = Math.max(price, getPriceFromString(priceString, !euroFormat));
+    }
     logger.debug('received price', price);
     return price;
   }

--- a/src/store/includes-labels.ts
+++ b/src/store/includes-labels.ts
@@ -125,10 +125,14 @@ export async function getPrice(
   const priceString = await extractPageContents(page, selector);
 
   if (priceString) {
+    const euroFormat = priceString.indexOf('.') < priceString.indexOf(',');
     const price = Number.parseFloat(
-      priceString.replace(/\\.|\\,/g, '').match(/\d+/g)!.join('.') // eslint-disable-line
+      priceString
+        .replace(/\\/g, '')
+        .replace(euroFormat ? /\./g : /,/g, '')
+        .match(/\d+/g)!
+        .join('.')
     );
-
     logger.debug('received price', price);
     return price;
   }


### PR DESCRIPTION
### Description

Fixed parsing prices with thousands separator and European.
The problem was introduced by #2131 and described here #2151
Example: Newegg Canada's price for RTX 3070 "1,600.00" was interpreted as 1.6 

### Testing

Tested manually and with a variety of stores around the world.
