### PR TITLE
chore(amazon-uk): add 3060 cards

### DIFF
--- a/src/store/model/amazon-uk.ts
+++ b/src/store/model/amazon-uk.ts
@@ -495,6 +495,222 @@ export const AmazonUk: Store = {
       series: '3060ti',
       url: 'https://www.amazon.co.uk/dp/B08PDMVPZ4',
     },
+    {
+      brand: 'zotac',
+      cartUrl:
+        'https://www.amazon.co.uk/gp/aws/cart/add.html?ASIN.1=B08W8DGK3X&Quantity.1=1',
+      model: 'twin edge oc',
+      series: '3060',
+      url: 'https://smile.amazon.co.uk/dp/B08W8DGK3X',
+    },
+    {
+      brand: 'palit',
+      cartUrl:
+        'https://www.amazon.co.uk/gp/aws/cart/add.html?ASIN.1=B08WRBF83Y&Quantity.1=1',
+      model: 'dual oc',
+      series: '3060',
+      url: 'https://smile.amazon.co.uk/dp/B08WRBF83Y',
+    },
+    {
+      brand: 'kfa2',
+      cartUrl:
+        'https://www.amazon.co.uk/gp/aws/cart/add.html?ASIN.1=B08ZJPGJ1B&Quantity.1=1',
+      model: 'dual oc',
+      series: '3060',
+      url: 'https://smile.amazon.co.uk/dp/B08ZJPGJ1B',
+    },
+    {
+      brand: 'msi',
+      cartUrl:
+        'https://www.amazon.co.uk/gp/aws/cart/add.html?ASIN.1=B08WH4RK2C&Quantity.1=1',
+      model: 'gaming x trio',
+      series: '3060',
+      url: 'https://smile.amazon.co.uk/dp/B08WH4RK2C',
+    },
+    {
+      brand: 'msi',
+      cartUrl:
+        'https://www.amazon.co.uk/gp/aws/cart/add.html?ASIN.1=B08WHML7GL&Quantity.1=1',
+      model: 'gaming x',
+      series: '3060',
+      url: 'https://smile.amazon.co.uk/dp/B08WHML7GL',
+    },
+    {
+      brand: 'pny',
+      cartUrl:
+        'https://www.amazon.co.uk/gp/aws/cart/add.html?ASIN.1=B08X12YK8G&Quantity.1=1',
+      model: 'xlr8 epic x',
+      series: '3060',
+      url: 'https://smile.amazon.co.uk/dp/B08X12YK8G',
+    },
+    {
+      brand: 'gigabyte',
+      cartUrl:
+        'https://www.amazon.co.uk/gp/aws/cart/add.html?ASIN.1=B08WBB3ZMJ&Quantity.1=1',
+      model: 'eagle oc',
+      series: '3060',
+      url: 'https://smile.amazon.co.uk/dp/B08WBB3ZMJ',
+    },
+    {
+      brand: 'gainward',
+      cartUrl:
+        'https://www.amazon.co.uk/gp/aws/cart/add.html?ASIN.1=B08X4Y9FQN&Quantity.1=1',
+      model: 'ghost oc',
+      series: '3060',
+      url: 'https://smile.amazon.co.uk/dp/B08X4Y9FQN',
+    },
+    {
+      brand: 'msi',
+      cartUrl:
+        'https://www.amazon.co.uk/gp/aws/cart/add.html?ASIN.1=B08WRP83LN&Quantity.1=1',
+      model: 'ventus 3x oc',
+      series: '3060',
+      url: 'https://smile.amazon.co.uk/dp/B08WRP83LN',
+    },
+    {
+      brand: 'asus',
+      cartUrl:
+        'https://www.amazon.co.uk/gp/aws/cart/add.html?ASIN.1=B08WGTL4CW&Quantity.1=1',
+      model: 'strix oc',
+      series: '3060',
+      url: 'https://smile.amazon.co.uk/dp/B08WGTL4CW',
+    },
+    {
+      brand: 'msi',
+      cartUrl:
+        'https://www.amazon.co.uk/gp/aws/cart/add.html?ASIN.1=B08WT47L8B&Quantity.1=1',
+      model: 'gaming x trio',
+      series: '3060',
+      url: 'https://smile.amazon.co.uk/dp/B08WT47L8B',
+    },
+    {
+      brand: 'msi',
+      cartUrl:
+        'https://www.amazon.co.uk/gp/aws/cart/add.html?ASIN.1=B08WHJFYM8&Quantity.1=1',
+      model: 'ventus 2x',
+      series: '3060',
+      url: 'https://smile.amazon.co.uk/dp/B08WHJFYM8',
+    },
+    {
+      brand: 'zotac',
+      cartUrl:
+        'https://www.amazon.co.uk/gp/aws/cart/add.html?ASIN.1=B08WRK84PS&Quantity.1=1',
+      model: 'twin edge oc',
+      series: '3060',
+      url: 'https://smile.amazon.co.uk/dp/B08WRK84PS',
+    },
+    {
+      brand: 'zotac',
+      cartUrl:
+        'https://www.amazon.co.uk/gp/aws/cart/add.html?ASIN.1=B08WRV24YD&Quantity.1=1',
+      model: 'amp white',
+      series: '3060',
+      url: 'https://smile.amazon.co.uk/dp/B08WRV24YD',
+    },
+    {
+      brand: 'evga',
+      cartUrl:
+        'https://www.amazon.co.uk/gp/aws/cart/add.html?ASIN.1=B08XQWR62V&Quantity.1=1',
+      model: 'xc gaming',
+      series: '3060',
+      url: 'https://smile.amazon.co.uk/dp/B08XQWR62V',
+    },
+    {
+      brand: 'kfa2',
+      cartUrl:
+        'https://www.amazon.co.uk/gp/aws/cart/add.html?ASIN.1=B08Y92K1DZ&Quantity.1=1',
+      model: 'gaming',
+      series: '3060',
+      url: 'https://smile.amazon.co.uk/dp/B08Y92K1DZ',
+    },
+    {
+      brand: 'evga',
+      cartUrl:
+        'https://www.amazon.co.uk/gp/aws/cart/add.html?ASIN.1=B08WM28PVH&Quantity.1=1',
+      model: 'xc gaming',
+      series: '3060',
+      url: 'https://smile.amazon.co.uk/dp/B08WM28PVH',
+    },
+    {
+      brand: 'gigabyte',
+      cartUrl:
+        'https://www.amazon.co.uk/gp/aws/cart/add.html?ASIN.1=B08WS5X6F5&Quantity.1=1',
+      model: 'aorus',
+      series: '3060',
+      url: 'https://smile.amazon.co.uk/dp/B08WS5X6F5',
+    },
+    {
+      brand: 'asus',
+      cartUrl:
+        'https://www.amazon.co.uk/gp/aws/cart/add.html?ASIN.1=B08WHJPBFX&Quantity.1=1',
+      model: 'tuf oc',
+      series: '3060',
+      url: 'https://smile.amazon.co.uk/dp/B08WHJPBFX',
+    },
+    {
+      brand: 'pny',
+      cartUrl:
+        'https://www.amazon.co.uk/gp/aws/cart/add.html?ASIN.1=B08WS1R9CM&Quantity.1=1',
+      model: 'uprising',
+      series: '3060',
+      url: 'https://smile.amazon.co.uk/dp/B08WS1R9CM',
+    },
+    {
+      brand: 'pny',
+      cartUrl:
+        'https://www.amazon.co.uk/gp/aws/cart/add.html?ASIN.1=B08WRQ3JR1&Quantity.1=1',
+      model: 'xlr8 revel',
+      series: '3060',
+      url: 'https://smile.amazon.co.uk/dp/B08WRQ3JR1',
+    },
+    {
+      brand: 'gigabyte',
+      cartUrl:
+        'https://www.amazon.co.uk/gp/aws/cart/add.html?ASIN.1=B08WBB7KXV&Quantity.1=1',
+      model: 'vision oc',
+      series: '3060',
+      url: 'https://smile.amazon.co.uk/dp/B08WBB7KXV',
+    },
+    {
+      brand: 'msi',
+      cartUrl:
+        'https://www.amazon.co.uk/gp/aws/cart/add.html?ASIN.1=B08WPJ5P4R&Quantity.1=1',
+      model: 'gaming x',
+      series: '3060',
+      url: 'https://smile.amazon.co.uk/dp/B08WPJ5P4R',
+    },
+    {
+      brand: 'asus',
+      cartUrl:
+        'https://www.amazon.co.uk/gp/aws/cart/add.html?ASIN.1=B08CRH6DYB&Quantity.1=1',
+      model: 'dual',
+      series: '3060',
+      url: 'https://smile.amazon.co.uk/dp/B08CRH6DYB',
+    },
+    {
+      brand: 'asus',
+      cartUrl:
+        'https://www.amazon.co.uk/gp/aws/cart/add.html?ASIN.1=B08CRH6DYB&Quantity.1=1',
+      model: 'dual',
+      series: '3060',
+      url: 'https://smile.amazon.co.uk/dp/B08CRH6DYB',
+    },
+    {
+      brand: 'msi',
+      cartUrl:
+        'https://www.amazon.co.uk/gp/aws/cart/add.html?ASIN.1=B08WPRMVWB&Quantity.1=1',
+      model: 'ventus 2x oc',
+      series: '3060',
+      url: 'https://smile.amazon.co.uk/dp/B08WPRMVWB',
+    },
+    {
+      brand: 'zotac',
+      cartUrl:
+        'https://www.amazon.co.uk/gp/aws/cart/add.html?ASIN.1=B08WRF18SC&Quantity.1=1',
+      model: 'twin edge',
+      series: '3060',
+      url: 'https://smile.amazon.co.uk/dp/B08WRF18SC',
+    },
   ],
   name: 'amazon-uk',
 };


### PR DESCRIPTION
This commit include a list of all the 3060 available by search on Amazon, used "include out of stock" option to collect them.
