### PR TITLE
feat: color empty stores

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "twilio": "^3.59.0",
         "twitch": "^4.5.2",
         "twitch-auth": "^4.5.2",
-        "twitch-chat-client": "^4.5.2",
+        "twitch-chat-client": "^4.5.4",
         "twitter": "^1.7.1",
         "winston": "^3.3.3"
       },
@@ -11123,41 +11123,41 @@
       }
     },
     "node_modules/twitch-api-call": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/twitch-api-call/-/twitch-api-call-4.5.2.tgz",
-      "integrity": "sha512-crJgecBtNT+uCFvLFgv5hA9XMEYrcNEyvClpUnA7ieQQIGe0zPHokQv775UYqnTfAlRX5sV27CgXHIz+T03x+A==",
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/twitch-api-call/-/twitch-api-call-4.5.4.tgz",
+      "integrity": "sha512-AXo1Yo1D3QaSx8lNgP8pmhh/Q92279d9oKYIqe28TNE86Gthkaddvg1sSabc9pDXCaOXUdj/Qw2OrVH/gocuTg==",
       "dependencies": {
         "@d-fischer/cross-fetch": "^4.0.2",
         "@d-fischer/qs": "^7.0.2",
         "@types/node-fetch": "^2.5.7",
         "node-fetch": "^2.6.1",
         "tslib": "^2.0.3",
-        "twitch-common": "^4.5.2"
+        "twitch-common": "^4.5.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/d-fischer"
       }
     },
     "node_modules/twitch-auth": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/twitch-auth/-/twitch-auth-4.5.2.tgz",
-      "integrity": "sha512-91O+qzSOoL8xWSvqOXWkwG/NmyNHcIYDxAhpLctJDoJ4ZAop1zI4T9kDCpj42XEnK3yGiLnbkwMhqs50AyN+Kw==",
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/twitch-auth/-/twitch-auth-4.5.4.tgz",
+      "integrity": "sha512-C7+T4tiLYZDICa3RDWBy8a4ciBFGAvhLYAQShg4lFNo049yDNoIInkIkDClHjLUZFQ9tTN7dTmJWLo3zN/Yp5w==",
       "dependencies": {
         "@d-fischer/deprecate": "^2.0.2",
         "@d-fischer/logger": "^3.1.0",
         "@d-fischer/shared-utils": "^3.0.1",
         "tslib": "^2.0.3",
-        "twitch-api-call": "^4.5.2",
-        "twitch-common": "^4.5.2"
+        "twitch-api-call": "^4.5.4",
+        "twitch-common": "^4.5.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/d-fischer"
       }
     },
     "node_modules/twitch-chat-client": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/twitch-chat-client/-/twitch-chat-client-4.5.2.tgz",
-      "integrity": "sha512-0po7BJWssB7mVYkXoapNWwWFKVMKNlJOygxQVkH9kinrEgjsxfcROC4ZnLaH56kLLtHWc7pFF80tir+VhkD7Lg==",
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/twitch-chat-client/-/twitch-chat-client-4.5.4.tgz",
+      "integrity": "sha512-0hMIyT4MHRXDlWdA5k26ixmiVOnlL7xnDk+VmiDZIshuKCX5qQNh2xJxhVopQQJY8kVOMqLutKftblabG16IKA==",
       "dependencies": {
         "@d-fischer/cache-decorators": "^2.1.1",
         "@d-fischer/deprecate": "^2.0.2",
@@ -11167,8 +11167,8 @@
         "@d-fischer/typed-event-emitter": "^3.2.2",
         "ircv3": "^0.26.13",
         "tslib": "^2.0.3",
-        "twitch-auth": "^4.5.2",
-        "twitch-common": "^4.5.2"
+        "twitch-auth": "^4.5.4",
+        "twitch-common": "^4.5.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/d-fischer"
@@ -11178,9 +11178,9 @@
       }
     },
     "node_modules/twitch-common": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/twitch-common/-/twitch-common-4.5.2.tgz",
-      "integrity": "sha512-GCOd7k8Bdz987EcPyuuepYAp4p23TUhGcpblH7NS3PX0hg+UN5mbCG8lsrva3X+nAAyUWiwjhu7g00UvTWLgGg==",
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/twitch-common/-/twitch-common-4.5.4.tgz",
+      "integrity": "sha512-f1x/wNYe3JUV0cqcFRiRHVDnMHskVM3Lt1fb5lbA4ZxfJdXOsQd5kkm3PcdJKYEA5bDl8mB4HktrGB8eTom63g==",
       "dependencies": {
         "@d-fischer/logger": "^3.1.0",
         "@d-fischer/shared-utils": "^3.0.1",
@@ -20710,35 +20710,35 @@
       }
     },
     "twitch-api-call": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/twitch-api-call/-/twitch-api-call-4.5.2.tgz",
-      "integrity": "sha512-crJgecBtNT+uCFvLFgv5hA9XMEYrcNEyvClpUnA7ieQQIGe0zPHokQv775UYqnTfAlRX5sV27CgXHIz+T03x+A==",
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/twitch-api-call/-/twitch-api-call-4.5.4.tgz",
+      "integrity": "sha512-AXo1Yo1D3QaSx8lNgP8pmhh/Q92279d9oKYIqe28TNE86Gthkaddvg1sSabc9pDXCaOXUdj/Qw2OrVH/gocuTg==",
       "requires": {
         "@d-fischer/cross-fetch": "^4.0.2",
         "@d-fischer/qs": "^7.0.2",
         "@types/node-fetch": "^2.5.7",
         "node-fetch": "^2.6.1",
         "tslib": "^2.0.3",
-        "twitch-common": "^4.5.2"
+        "twitch-common": "^4.5.4"
       }
     },
     "twitch-auth": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/twitch-auth/-/twitch-auth-4.5.2.tgz",
-      "integrity": "sha512-91O+qzSOoL8xWSvqOXWkwG/NmyNHcIYDxAhpLctJDoJ4ZAop1zI4T9kDCpj42XEnK3yGiLnbkwMhqs50AyN+Kw==",
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/twitch-auth/-/twitch-auth-4.5.4.tgz",
+      "integrity": "sha512-C7+T4tiLYZDICa3RDWBy8a4ciBFGAvhLYAQShg4lFNo049yDNoIInkIkDClHjLUZFQ9tTN7dTmJWLo3zN/Yp5w==",
       "requires": {
         "@d-fischer/deprecate": "^2.0.2",
         "@d-fischer/logger": "^3.1.0",
         "@d-fischer/shared-utils": "^3.0.1",
         "tslib": "^2.0.3",
-        "twitch-api-call": "^4.5.2",
-        "twitch-common": "^4.5.2"
+        "twitch-api-call": "^4.5.4",
+        "twitch-common": "^4.5.4"
       }
     },
     "twitch-chat-client": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/twitch-chat-client/-/twitch-chat-client-4.5.2.tgz",
-      "integrity": "sha512-0po7BJWssB7mVYkXoapNWwWFKVMKNlJOygxQVkH9kinrEgjsxfcROC4ZnLaH56kLLtHWc7pFF80tir+VhkD7Lg==",
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/twitch-chat-client/-/twitch-chat-client-4.5.4.tgz",
+      "integrity": "sha512-0hMIyT4MHRXDlWdA5k26ixmiVOnlL7xnDk+VmiDZIshuKCX5qQNh2xJxhVopQQJY8kVOMqLutKftblabG16IKA==",
       "requires": {
         "@d-fischer/cache-decorators": "^2.1.1",
         "@d-fischer/deprecate": "^2.0.2",
@@ -20748,14 +20748,14 @@
         "@d-fischer/typed-event-emitter": "^3.2.2",
         "ircv3": "^0.26.13",
         "tslib": "^2.0.3",
-        "twitch-auth": "^4.5.2",
-        "twitch-common": "^4.5.2"
+        "twitch-auth": "^4.5.4",
+        "twitch-common": "^4.5.4"
       }
     },
     "twitch-common": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/twitch-common/-/twitch-common-4.5.2.tgz",
-      "integrity": "sha512-GCOd7k8Bdz987EcPyuuepYAp4p23TUhGcpblH7NS3PX0hg+UN5mbCG8lsrva3X+nAAyUWiwjhu7g00UvTWLgGg==",
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/twitch-common/-/twitch-common-4.5.4.tgz",
+      "integrity": "sha512-f1x/wNYe3JUV0cqcFRiRHVDnMHskVM3Lt1fb5lbA4ZxfJdXOsQd5kkm3PcdJKYEA5bDl8mB4HktrGB8eTom63g==",
       "requires": {
         "@d-fischer/logger": "^3.1.0",
         "@d-fischer/shared-utils": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "twilio": "^3.59.0",
     "twitch": "^4.5.2",
     "twitch-auth": "^4.5.2",
-    "twitch-chat-client": "^4.5.2",
+    "twitch-chat-client": "^4.5.4",
     "twitter": "^1.7.1",
     "winston": "^3.3.3"
   },

--- a/src/store/model/index.ts
+++ b/src/store/model/index.ts
@@ -146,6 +146,7 @@ import {Wipoid} from './wipoid';
 import {Xbox} from './xbox';
 import {Zotac} from './zotac';
 import {logger} from '../../logger';
+import chalk from 'chalk';
 
 export const storeList = new Map([
   [AComPC.name, AComPC],
@@ -323,14 +324,6 @@ function filterBrandsSeriesModels() {
 }
 
 function printConfig() {
-  if (config.store.stores.length > 0) {
-    logger.info(
-      `ℹ selected stores: ${config.store.stores
-        .map(store => store.name)
-        .join(', ')}`
-    );
-  }
-
   if (config.store.showOnlyBrands.length > 0) {
     logger.info(`ℹ selected brands: ${config.store.showOnlyBrands.join(', ')}`);
   }
@@ -350,6 +343,38 @@ function printConfig() {
   if (config.store.showOnlySeries.length > 0) {
     logger.info(`ℹ selected series: ${config.store.showOnlySeries.join(', ')}`);
   }
+
+  if (config.store.stores.length > 0) {
+    const stores = darkenEmptyStores();
+    logger.info(`ℹ selected stores: ${stores.names.join(', ')}`);
+
+    if (stores.anyExcluded) {
+      logger.warn(
+        'ℹ some of the selected stores (grayed out) dont have what you are looking for'
+      );
+    }
+  }
+}
+
+function darkenEmptyStores(): {names: string[]; anyExcluded: boolean} {
+  let anyExcluded = false;
+  const selectedStores = config.store.stores.map(store => store.name);
+
+  const names = selectedStores.map(selected => {
+    const storeConfig = storeList.get(selected);
+    const hasAny =
+      storeConfig?.links.some(
+        l =>
+          (config.store.showOnlySeries?.includes(l.series) ?? false) ||
+          config.store.showOnlyBrands?.includes(l.brand ?? false) ||
+          (config.store.showOnlyModels?.map(m => m.name).includes(l.model) ??
+            false)
+      ) ?? false;
+
+    anyExcluded = anyExcluded || !hasAny;
+    return hasAny ? selected : chalk.gray(selected);
+  });
+  return {names, anyExcluded};
 }
 
 function warnIfStoreDeprecated(store: Store) {


### PR DESCRIPTION
### Description

Applies to the `selected stores` information on startup.

Grayes out stores that have none of the selected brands/series/models as links. Additionally, if described event occurs, prints a line describing that some of the selected stores dont have what the user is looking for.

Prevents users (like me) from thinking the bot wouldn't work correctly because it isn't checking specific stores.

### Testing

Tested across series, models, brands for 3070 and 3080 on alternate and amd. Successfully grayed out not matching stores.

### New dependencies

None.
