### PR TITLE
chore(amd): add rx6800xt midnight black

### DIFF
--- a/src/store/model/amd-ca.ts
+++ b/src/store/model/amd-ca.ts
@@ -43,6 +43,14 @@ export const AmdCa: Store = {
       series: 'rx6900xt',
       url: 'https://www.amd.com/en/direct-buy/5458372200/ca',
     },
+    {
+      brand: 'amd',
+      cartUrl:
+        'https://www.amd.com/en/direct-buy/5496921500/ca?add-to-cart=true',
+      model: 'amd reference',
+      series: 'rx6800xt',
+      url: 'https://www.amd.com/en/direct-buy/5496921500/ca',
+    },
   ],
   name: 'amd-ca',
 };

--- a/src/store/model/amd-de.ts
+++ b/src/store/model/amd-de.ts
@@ -79,6 +79,14 @@ export const AmdDe: Store = {
       series: 'rx6900xt',
       url: 'https://www.amd.com/de/direct-buy/5458374200/de',
     },
+    {
+      brand: 'amd',
+      cartUrl:
+        'https://www.amd.com/de/direct-buy/5496921500/de?add-to-cart=true',
+      model: 'amd reference',
+      series: 'rx6800xt',
+      url: 'https://www.amd.com/de/direct-buy/5496921500/de',
+    },
   ],
   name: 'amd-de',
 };

--- a/src/store/model/amd-it.ts
+++ b/src/store/model/amd-it.ts
@@ -59,6 +59,14 @@ export const AmdIt: Store = {
       series: 'rx6800xt',
       url: 'https://www.amd.com/en/direct-buy/5458374100/it',
     },
+    {
+      brand: 'amd',
+      cartUrl:
+        'https://www.amd.com/en/direct-buy/5496921500/it?add-to-cart=true',
+      model: 'amd reference',
+      series: 'rx6800xt',
+      url: 'https://www.amd.com/en/direct-buy/5496921500/it',
+    },
   ],
   name: 'amd-it',
 };

--- a/src/store/model/amd-uk.ts
+++ b/src/store/model/amd-uk.ts
@@ -91,6 +91,14 @@ export const AmdUk: Store = {
       series: 'rx6900xt',
       url: 'https://www.amd.com/en/direct-buy/5458374200/gb',
     },
+    {
+      brand: 'amd',
+      cartUrl:
+        'https://www.amd.com/en/direct-buy/5496921500/gb?add-to-cart=true',
+      model: 'amd reference',
+      series: 'rx6800xt',
+      url: 'https://www.amd.com/en/direct-buy/5496921500/gb',
+    },
   ],
   name: 'amd-uk',
 };

--- a/src/store/model/amd.ts
+++ b/src/store/model/amd.ts
@@ -75,6 +75,14 @@ export const Amd: Store = {
       series: 'rx6800',
       url: 'https://www.amd.com/en/direct-buy/5458373400/us',
     },
+    {
+      brand: 'amd',
+      cartUrl:
+        'https://www.amd.com/en/direct-buy/5496921500/us?add-to-cart=true',
+      model: 'amd reference',
+      series: 'rx6800xt',
+      url: 'https://www.amd.com/en/direct-buy/5496921500/us',
+    },
   ],
   name: 'amd',
 };


### PR DESCRIPTION
<!-- Please use Conventional Commits to label your title -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/ -->
<!-- Example: feat: allow provided config object to extend other configs  -->

### Description

AMD released a new version of the reference RX6800 XT on their shop yesterday. I have added the links to all relevant `amd` stores.

### Testing

Created a new model for it in `store.ts` and made sure that specific link gets tested. Reports back stock correctly. For upstream, I left the model at `amd reference`, as it's just a black variant of the reference card.
