### PR TITLE
fix(discord): properly wait for webhooks

### DIFF
--- a/src/notification/discord.ts
+++ b/src/notification/discord.ts
@@ -54,7 +54,6 @@ export function sendDiscordMessage(link: Link, store: Store) {
         const notifyKeys = Object.keys(notifyGroupSeries);
         const notifyIndex = notifyKeys.indexOf(link.series);
         if (notifyIndex !== -1) {
-          // notifyGroupSeries.
           notifyText = notifyText.concat(notifyKeys[notifyIndex]);
         }
 

--- a/src/notification/discord.ts
+++ b/src/notification/discord.ts
@@ -54,27 +54,36 @@ export function sendDiscordMessage(link: Link, store: Store) {
         const notifyKeys = Object.keys(notifyGroupSeries);
         const notifyIndex = notifyKeys.indexOf(link.series);
         if (notifyIndex !== -1) {
-          notifyText = notifyText.concat(Object.values(notifyGroupSeries)[notifyIndex]);
+          notifyText = notifyText.concat(
+            Object.values(notifyGroupSeries)[notifyIndex]
+          );
         }
 
-        let promises = [];
+        const promises = [];
         for (const webhook of webhooks) {
           const {id, token} = getIdAndToken(webhook);
           const client = new Discord.WebhookClient(id, token);
 
-          promises.push(new Promise((resolve, reject) => {
-            client.send(notifyText.join(' '), {
-              embeds: [embed],
-              username: 'streetmerchant',
-            }).then((resp) => {
-              logger.info("✔ discord message sent resp.id: " + resp.id);
-              resolve(resp);
-            }).catch((err) => reject(err)
-            ).finally(() => client.destroy());
-          }));
+          promises.push(
+            new Promise((resolve, reject) => {
+              client
+                .send(notifyText.join(' '), {
+                  embeds: [embed],
+                  username: 'streetmerchant',
+                })
+                .then(resp => {
+                  logger.info('✔ discord message sent resp.id: ' + resp.id);
+                  resolve(resp);
+                })
+                .catch(err => reject(err))
+                .finally(() => client.destroy());
+            })
+          );
         }
 
-        (await Promise.all(promises).catch((err) => logger.error("✖ couldn't send discord message", err)));
+        await Promise.all(promises).catch(err =>
+          logger.error("✖ couldn't send discord message", err)
+        );
       } catch (error: unknown) {
         logger.error("✖ couldn't send discord message", error);
       }

--- a/src/notification/discord.ts
+++ b/src/notification/discord.ts
@@ -54,7 +54,7 @@ export function sendDiscordMessage(link: Link, store: Store) {
         const notifyKeys = Object.keys(notifyGroupSeries);
         const notifyIndex = notifyKeys.indexOf(link.series);
         if (notifyIndex !== -1) {
-          notifyText = notifyText.concat(notifyKeys[notifyIndex]);
+          notifyText = notifyText.concat(Object.values(notifyGroupSeries)[notifyIndex]);
         }
 
         let promises = [];

--- a/src/notification/discord.ts
+++ b/src/notification/discord.ts
@@ -51,28 +51,31 @@ export function sendDiscordMessage(link: Link, store: Store) {
         if (notifyGroup) {
           notifyText = notifyText.concat(notifyGroup);
         }
-
-        if (Object.keys(notifyGroupSeries).indexOf(link.series) !== -1) {
-          notifyText = notifyText.concat(notifyGroupSeries[link.series]);
+        const notifyKeys = Object.keys(notifyGroupSeries);
+        const notifyIndex = notifyKeys.indexOf(link.series);
+        if (notifyIndex !== -1) {
+          // notifyGroupSeries.
+          notifyText = notifyText.concat(notifyKeys[notifyIndex]);
         }
 
-        const promises = [];
+        let promises = [];
         for (const webhook of webhooks) {
           const {id, token} = getIdAndToken(webhook);
           const client = new Discord.WebhookClient(id, token);
 
-          promises.push({
-            client,
-            message: client.send(notifyText.join(' '), {
+          promises.push(new Promise((resolve, reject) => {
+            client.send(notifyText.join(' '), {
               embeds: [embed],
               username: 'streetmerchant',
-            }),
-          });
+            }).then((resp) => {
+              logger.info("✔ discord message sent resp.id: " + resp.id);
+              resolve(resp);
+            }).catch((err) => reject(err)
+            ).finally(() => client.destroy());
+          }));
         }
 
-        (await Promise.all(promises)).forEach(({client}) => client.destroy());
-
-        logger.info('✔ discord message sent');
+        (await Promise.all(promises).catch((err) => logger.error("✖ couldn't send discord message", err)));
       } catch (error: unknown) {
         logger.error("✖ couldn't send discord message", error);
       }


### PR DESCRIPTION
### Description
This commit adds promise resolution and objects to
be properly used within Promise.all function.
Before the `try {} catch {}` block would be exited
before the clients resolved their requests causing
uncaught errors from the notifications.
Also added object indexing to the notifyGroupSeries variable
to prevent typescript compile error.

Potentially Fixes:
- https://github.com/jef/streetmerchant/issues/2252

I failed to receive one of my alerts because of a uncaught error emanating from the discord notification webhook.

```
streetmerchant    | [6:52:25 PM] info :: 🚀🚨 [amazon] [{series} ({model})] ... :: IN STOCK 🚨🚀
streetmerchant    | https://www.amazon.com/gp/aws/cart/add.html?ASIN.1=...&Quantity.1=1
streetmerchant    | [6:52:25 PM] info :: ✔ discord message sent <--- Here the app is resolving out of the `try catch` block
streetmerchant    | /app/node_modules/discord.js/src/rest/RequestHandler.js:93 <--- Then fails to handle the 500 resp
streetmerchant    |         throw new HTTPError(error.message, error.constructor.name, error.status, request.method, request.path);
streetmerchant    |               ^
streetmerchant    |
streetmerchant    | HTTPError [FetchError]: request to https://discord.com/api/v7/webhooks/.../...?wait=true failed, reason: getaddrinfo EAI_AGAIN discord.com
streetmerchant    |     at RequestHandler.execute (/app/node_modules/discord.js/src/rest/RequestHandler.js:93:15)
streetmerchant    |     at runMicrotasks (<anonymous>)
streetmerchant    |     at processTicksAndRejections (node:internal/process/task_queues:94:5)
streetmerchant    |     at async RequestHandler.push (/app/node_modules/discord.js/src/rest/RequestHandler.js:39:14) {
streetmerchant    |   code: 500,
streetmerchant    |   method: 'post',
streetmerchant    |   path: '/webhooks/.../...?wait=true'
streetmerchant    | }
```

The `500` error I received might have been caused by the client being destroyed before the requests were resolved as I don't believe that `Promise.all` taking in an array of objects will know how to resolve the promises. These changes explicitly handle the promises and resolutions/catching of each webhook client.

### Testing
`npm run test:notification`
You can see that the logger is not called until the response is received by the client for each webhook.
