### PR TITLE
fix(amazon-es): use euroFormat

### DIFF
--- a/src/store/model/amazon-es.ts
+++ b/src/store/model/amazon-es.ts
@@ -14,6 +14,7 @@ export const AmazonEs: Store = {
     },
     maxPrice: {
       container: '#priceblock_ourprice',
+      euroFormat: true,
     },
     outOfStock: [
       {


### PR DESCRIPTION
It was parsing 1800 as 1.8 resulting in unwanted notifications. Now it seems to work correctly.