### PR TITLE
fix(alternate): use button selector instead of text

### DIFF
--- a/src/store/model/alternate.ts
+++ b/src/store/model/alternate.ts
@@ -4,13 +4,8 @@ export const Alternate: Store = {
   currency: '€',
   labels: {
     inStock: {
-      container: 'span.d-flex > b:nth-child(1)',
-      text: [
-        'auf lager',
-        'ware neu eingetroffen',
-        'in kürze versandfertig',
-        'ware im zulauf',
-      ],
+      container: '.details-cart-button',
+      text: ['In den Warenkorb'],
     },
     maxPrice: {
       container: '.price > span:nth-child(1)',


### PR DESCRIPTION
it often says "in stock" while also saying that it cannot be purchased instead of showing the cart button

![2021-04-23_00-39](https://user-images.githubusercontent.com/5680466/115788682-985fc080-a3cc-11eb-9332-caadf11f1873.png)
