### PR TITLE
feat: add waitUntil and waitForSelctor to linksBuilder

### DIFF
--- a/src/store/model/store.ts
+++ b/src/store/model/store.ts
@@ -251,6 +251,8 @@ export type Store = {
   linksBuilder?: {
     builder: (docElement: cheerio.Cheerio, series: Series) => Link[];
     ttl?: number;
+    waitUntil?: PuppeteerLifeCycleEvent;
+    waitForSelector?: string;
     urls: Array<{series: Series; url: string | string[]}>;
   };
   labels: Labels;


### PR DESCRIPTION
I was trying to add a linksBuilder for some store, but the store loads the search results via ajax, so they were not in the response passed to linksBuilder.

Added two new options for linksBuilder:

- `waitUntil` - the same as in Store. allows to specify one of the `PuppeteerLifeCycleEvent` values.
- `waitForSelctor` - wait for the specified element to appear, using puppeteer's `page.waitForSelctor()`.