### PR TITLE
fix(lookup): prevent terminal from being hidden

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "node-notifier": "^9.0.1",
     "node-pagerduty": "^1.3.6",
     "nodemailer": "^6.5.0",
-    "open": "^8.0.6",
+    "open": "8.0.2",
     "play-sound": "^1.1.3",
     "puppeteer": "^9.0.0",
     "puppeteer-extra-plugin-adblocker": "^2.11.11",


### PR DESCRIPTION
<!-- Please use Conventional Commits to label your title -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/ -->
<!-- Example: feat: allow provided config object to extend other configs  -->

### Description

<!-- Fixes #(issue) -->
<!-- Please also include relevant motivation and context. -->
Fixes #2232, #2369

Known issue starting in `open=^8.0.3`, details [here](https://github.com/sindresorhus/open/pull/238). Pinning to 8.0.2 for now will resolve this while the linked PR is approved.

### Testing

<!-- Please describe the tests that you ran to verify your changes. -->
<!-- Provide instructions so we can reproduce. -->
<!-- Please also list any relevant details for your test configuration -->

- open `cmd`, navigate to sm directory
- run `npm i` with updated `package.json`
- ensure `OPEN_BROWSER` is not `false`
- run `npm run test:notification`, verify browser window opens while `cmd` window also remains open
- (can also run against test item and verify `cmd` continues processing after opening browser when using `npm run start`)
