### PR TITLE
chore(otto): add labels for xbox series x & s

### DIFF
--- a/src/store/model/otto.ts
+++ b/src/store/model/otto.ts
@@ -71,6 +71,13 @@ export const Otto: Store = {
     },
     {
       brand: 'microsoft',
+      labels: {
+        inStock: {
+          container:
+            '.js_shortInfo__variationName.prd_shortInfo__variationName',
+          text: ['Xbox Series S'],
+        },
+      },
       model: 'xbox series s',
       series: 'xboxss',
       url:
@@ -78,6 +85,13 @@ export const Otto: Store = {
     },
     {
       brand: 'microsoft',
+      labels: {
+        inStock: {
+          container:
+            '.js_shortInfo__variationName.prd_shortInfo__variationName',
+          text: ['Xbox Series X'],
+        },
+      },
       model: 'xbox series x',
       series: 'xboxsx',
       url:


### PR DESCRIPTION
### Description

fixes false positives for the series x (screenshot shows the series s page after redirect)

### Testing

tested with docker local and the alert for series s still works. could not test series x because the page is currently hidden. 
