### PR TITLE
fix: clear cookies when rotating proxies

### DIFF
--- a/src/store/lookup.ts
+++ b/src/store/lookup.ts
@@ -280,6 +280,15 @@ async function lookup(browser: Browser, store: Store) {
       await disableBlockerInPage(pageProxy);
     }
 
+    if (
+      store.currentProxyIndex !== undefined &&
+      store.proxyList &&
+      store.proxyList?.length > 1
+    ) {
+      const client = await page.target().createCDPSession();
+      await client.send('Network.clearBrowserCookies');
+    }
+
     // Must apply backoff before closing the page, e.g. if CloudFlare is
     // used to detect bot traffic, it introduces a 5 second page delay
     // before redirecting to the next page


### PR DESCRIPTION
### Description

Netonnet-no gives 403 even with many rotating proxies. I found out this is because a cookie. So the fix is to remove cookies before/after checking a new product. After getting a 403 it would work again (for a couple of products). This is because [cookies are cleared when an error occured](https://github.com/jef/streetmerchant/blob/main/src/store/lookup.ts#L276). 

Adding stores have been easy but I know I'm on deep water when editing `lookup.ts` however I do believe it should clear cookies when getting a new proxy regardless of the store. 

### Testing
Tested 100+ product fetches on Netonnet-no, previously I would get 403 after 3-5 products. 
