### PR TITLE
fix(discord): add Discord.ClientOptions

### DIFF
--- a/src/messaging/discord.ts
+++ b/src/messaging/discord.ts
@@ -7,6 +7,9 @@ import {RawUserData} from 'discord.js/typings/rawDataTypes';
 
 const {notifyGroup, webhooks, notifyGroupSeries} = config.notifications.discord;
 const {pollInterval, responseTimeout, token, userId} = config.captchaHandler;
+const clientOptions: Discord.ClientOptions = {
+  intents: new Discord.Intents(),
+};
 
 function getIdAndToken(webhook: string) {
   const match = /.*\/webhooks\/(\d+)\/(.+)/.exec(webhook);
@@ -66,13 +69,13 @@ export function sendDiscordMessage(link: Link, store: Store) {
         const promises = [];
         for (const webhook of webhooks) {
           const {id, token} = getIdAndToken(webhook);
-          const client = new Discord.WebhookClient({id, token});
+          const client = new Discord.WebhookClient({id, token}, clientOptions);
 
           promises.push(
             new Promise((resolve, reject) => {
               client
                 .send({
-                  content: notifyText.join(' '),
+                  content: notifyText.length ? notifyText.join(' ') : null,
                   embeds: [embed],
                   username: 'streetmerchant',
                 })
@@ -199,7 +202,7 @@ export async function sendDMAndGetResponseAsync(
 async function getDiscordClientAsync() {
   let clientInstance = undefined;
   if (token) {
-    clientInstance = new Discord.Client({} as Discord.ClientOptions);
+    clientInstance = new Discord.Client(clientOptions);
     await clientInstance.login(token);
   }
   return clientInstance;


### PR DESCRIPTION
Otherwise, a "TypeError [CLIENT_MISSING_INTENTS]" is thrown due to the upgraded to discord.js v13 in f14a1ca7. For more informations visist [https://discordjs.guide/additional-info/changes-in-v13.html#intents](https://discordjs.guide/additional-info/changes-in-v13.html#intents) 

### Error message without this change
```
error :: ✖ couldn't send discord DM Valid intents must be provided for the Client. {
  "stack": "TypeError [CLIENT_MISSING_INTENTS]: Valid intents must be provided for the Client.
    at Client._validateOptions (/app/node_modules/discord.js/src/client/Client.js:544:13)
    at new Client (/app/node_modules/discord.js/src/client/Client.js:73:10)
    at getDiscordClientAsync (/app/build/src/messaging/discord.js:178:26)
    at sendDMAsync (/app/build/src/messaging/discord.js:86:28)
    at Object.sendDMAndGetResponseAsync (/app/build/src/messaging/discord.js:170:27)
    at Object.getCaptchaInputAsync (/app/build/src/messaging/captcha.js:19:36)
    at Object.handleCaptchaAsync (/app/build/src/store/captcha-handler.js:36:40)
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at async isItemInStock (/app/build/src/store/lookup.js:338:23)"
}
```

### Testing

run existing test script for notification and captcha