### PR TITLE
chore(store): EBGames renamed to Gamestop (in Canada)

### DIFF
--- a/docs/reference/filter.md
+++ b/docs/reference/filter.md
@@ -98,7 +98,6 @@ Used with the `STORES` variable.
 | DComp | AU | `dcomp`|
 | Drako | IT | `drako` |
 | DustinHome | NO | `dustinhome-no` |
-| EBGames | CA | `ebgames`|
 | eBuyer | UK | `ebuyer`|
 | El Corte Inglés | ES | `elcorteingles`|
 | Eletronicamente | ES | `eletronicamente`|
@@ -117,6 +116,7 @@ Used with the `STORES` variable.
 | Game | ES | `game-es`|
 | Game | UK | `game`|
 | Gamestop | US | `gamestop`|
+| Gamestop | CA | `gamestop-ca`|
 | Gamestop | DE | `gamestop-de`|
 | Gamestop | IE | `gamestop-ie`|
 | Gamestop | IT | `gamestop-it`|

--- a/src/store/model/gamestop-ca.ts
+++ b/src/store/model/gamestop-ca.ts
@@ -1,6 +1,6 @@
 import {Store} from './store';
 
-export const EbGames: Store = {
+export const GamestopCA: Store = {
   currency: '$',
   labels: {
     maxPrice: {
@@ -16,31 +16,31 @@ export const EbGames: Store = {
       brand: 'test:brand',
       model: 'test:model',
       series: 'test:series',
-      url: 'https://www.ebgames.ca/Switch/Games/727918/mario-kart-8-deluxe',
+      url: 'https://www.gamestop.ca/Switch/Games/727918/mario-kart-8-deluxe',
     },
     {
       brand: 'sony',
       model: 'ps5 console',
       series: 'sonyps5c',
-      url: 'https://www.ebgames.ca/PS5/Games/877522',
+      url: 'https://www.gamestop.ca/PS5/Games/877522',
     },
     {
       brand: 'sony',
       model: 'ps5 digital',
       series: 'sonyps5de',
-      url: 'https://www.ebgames.ca/PS5/Games/877523',
+      url: 'https://www.gamestop.ca/PS5/Games/877523',
     },
     {
       brand: 'microsoft',
       model: 'xbox series x',
       series: 'xboxsx',
-      url: 'https://www.ebgames.ca/Xbox%20Series%20X/Games/877779/xbox-series-x',
+      url: 'https://www.gamestop.ca/Xbox%20Series%20X/Games/877779/xbox-series-x',
     },
     {
       brand: 'microsoft',
       model: 'xbox series s',
       series: 'xboxss',
-      url: 'https://www.ebgames.ca/Xbox%20Series%20X/Games/877780/xbox-series-s',
+      url: 'https://www.gamestop.ca/Xbox%20Series%20X/Games/877780/xbox-series-s',
     },
   ],
   name: 'ebgames',

--- a/src/store/model/gamestop-ca.ts
+++ b/src/store/model/gamestop-ca.ts
@@ -43,5 +43,5 @@ export const GamestopCA: Store = {
       url: 'https://www.gamestop.ca/Xbox%20Series%20X/Games/877780/xbox-series-s',
     },
   ],
-  name: 'ebgames',
+  name: 'gamestop-ca',
 };

--- a/src/store/model/index.ts
+++ b/src/store/model/index.ts
@@ -63,7 +63,6 @@ import {CyberportAt} from './cyberport-at';
 import {Dcomp} from './dcomp';
 import {Drako} from './drako';
 import {DustinHomeNO} from './dustinhome-no';
-import {EbGames} from './ebgames';
 import {Ebuyer} from './ebuyer';
 import {Elcorteingles} from './elcorteingles';
 import {Eletronicamente} from './eletronicamente';
@@ -81,6 +80,7 @@ import {Galaxus} from './galaxus';
 import {Game} from './game';
 import {GameES} from './game-es';
 import {Gamestop} from './gamestop';
+import {GamestopCA} from './gamestop-ca';
 import {GamestopDE} from './gamestop-de';
 import {GamestopIE} from './gamestop-ie';
 import {GamestopIT} from './gamestop-it';
@@ -248,6 +248,7 @@ export const storeList = new Map([
   [Game.name, Game],
   [GameES.name, GameES],
   [Gamestop.name, Gamestop],
+  [GamestopCA.name, GamestopCA],
   [GamestopDE.name, GamestopDE],
   [GamestopIE.name, GamestopIE],
   [GamestopIT.name, GamestopIT],

--- a/src/store/model/index.ts
+++ b/src/store/model/index.ts
@@ -230,7 +230,6 @@ export const storeList = new Map([
   [Dcomp.name, Dcomp],
   [Drako.name, Drako],
   [DustinHomeNO.name, DustinHomeNO],
-  [EbGames.name, EbGames],
   [Ebuyer.name, Ebuyer],
   [Elcorteingles.name, Elcorteingles],
   [Eletronicamente.name, Eletronicamente],

--- a/src/store/model/xbox.ts
+++ b/src/store/model/xbox.ts
@@ -5,8 +5,8 @@ export const Xbox: Store = {
   labels: {
     outOfStock: {
       container:
-        '._-_-node_modules--xbox-web-partner-core-build-pages-BundleBuilder-Components-BundleBuilderHeader-__BundleBuilderHeader-module___checkoutButton',
-      text: ['out of stock'],
+        '[class="BundleBuilderHeader-module__checkoutButton___3UyEq w-100 bg-light-green btn btn-primary"]',
+      text: ['Out of stock'],
     },
   },
   links: [


### PR DESCRIPTION

### Description

EBGames has been renamed to Gamestop in Canada. I've removed `ebgames` and created `gamestop-ca` store. Also updated the store filter from the Docs.

### Testing

- Added `gamestop-ca` store in `dotenv` and tested with `sonyps5c`, `sonyps5de`.

- Tested positive result using `test:series`.