### PR TITLE
Add support for Xbox Series X and Xbox Series S on Microsoft Canada

### DIFF
--- a/src/store/model/index.ts
+++ b/src/store/model/index.ts
@@ -167,6 +167,7 @@ import {logger} from '../../logger';
 import chalk from 'chalk';
 import {UltimaInformatica} from './utlimainformatica';
 import {XtremMedia} from './xtremmedia';
+import { MicrosoftCA } from './microsoft-ca';
 
 export const storeList = new Map([
   [AComPC.name, AComPC],
@@ -269,6 +270,7 @@ export const storeList = new Map([
   [Materiel.name, Materiel],
   [MemoryExpress.name, MemoryExpress],
   [MicroCenter.name, MicroCenter],
+  [MicrosoftCA.name, MicrosoftCA],
   [MightyApe.name, MightyApe],
   [Mindfactory.name, Mindfactory],
   [Msy.name, Msy],

--- a/src/store/model/microsoft-ca.ts
+++ b/src/store/model/microsoft-ca.ts
@@ -1,0 +1,36 @@
+import {Store} from './store';
+
+export const MicrosoftCA: Store = {
+  currency: '$',
+  labels: {
+    inStock: {
+      container: 'button[aria-label="Checkout bundle"]',
+      text: ['Checkout'],
+    },
+    outOfStock: {
+      container: 'button[aria-label="Checkout bundle"]',
+      text: ['Out of stock'],
+    },
+  },
+  links: [
+    {
+      brand: 'test:brand',
+      model: 'test:model',
+      series: 'test:series',
+      url: 'https://www.xbox.com/en-ca/configure/8WJ714N3RBTL',
+    },
+    {
+      brand: 'microsoft',
+      model: 'xbox series x',
+      series: 'xboxsx',
+      url: 'https://www.xbox.com/en-ca/configure/8WJ714N3RBTL',
+    },
+    {
+      brand: 'microsoft',
+      model: 'xbox series s',
+      series: 'xboxss',
+      url: 'https://www.xbox.com/en-ca/configure/942J774TP9JN',
+    }
+  ],
+  name: 'microsoft-ca'
+};


### PR DESCRIPTION
### Description

Adds support for detecting xbox series x and xbox series s on the Canadian Microsoft store.

### Testing

Tested by running the script and detecting that the series x was available.
![image](https://user-images.githubusercontent.com/819171/132916188-76837b06-26e6-4782-98fe-01a7f8296d51.png)
