### PR TITLE
Fixed incorrect store description for alternate-de

### DIFF
--- a/docs/reference/filter.md
+++ b/docs/reference/filter.md
@@ -42,7 +42,7 @@ Used with the `STORES` variable.
 | Adorama | US | `adorama`|
 | Akinformatica | IT | `akinformatica`|
 | Allneeds | AU | `allneeds`|
-| Alternate | DE | `alternate`|
+| Alternate | DE | `alternate-de`|
 | Alternate | NL | `alternate-nl`|
 | Amazon | US | `amazon`|
 | Amazon | CA | `amazon-ca`|


### PR DESCRIPTION
Wiki was incorrectly listing the dotenv variable for Alternate Germany as "alternate", while it should have been "alternate-de".