### PR TITLE
Adds additional bundles to MediaMarkt (DE) & Saturn (DE)

### DIFF
--- a/src/store/model/mediamarkt.ts
+++ b/src/store/model/mediamarkt.ts
@@ -320,6 +320,36 @@ export const Mediamarkt: Store = {
     },
     {
       brand: 'sony',
+      model: 'ps5 console',
+      series: 'sonyps5c',
+      url: 'https://www.mediamarkt.de/de/product/_sony-ps5-ghost-of-tsushima-directors-cut-2757003.html',
+    },
+    {
+      brand: 'sony',
+      model: 'ps5 console',
+      series: 'sonyps5c',
+      url: 'https://www.mediamarkt.de/de/product/_sony-ps5-ratchet-clank-rift-apart-2741441.html',
+    },
+    {
+      brand: 'sony',
+      model: 'ps5 console',
+      series: 'sonyps5c',
+      url: 'https://www.mediamarkt.de/de/product/_sony-playstationr5-deathloop-death-stranding-dc-nur-online-2768018.html',
+    },
+    {
+      brand: 'sony',
+      model: 'ps5 console',
+      series: 'sonyps5c',
+      url: 'https://www.mediamarkt.de/de/product/_sony-playstationr5-death-stranding-directors-cut-nur-online-2765122.html',
+    },
+    {
+      brand: 'sony',
+      model: 'ps5 console',
+      series: 'sonyps5c',
+      url: 'https://www.mediamarkt.de/de/product/_sony-playstationr5-ghost-of-tsushima-death-stranding-dc-nur-online-2768019.html',
+    },
+    {
+      brand: 'sony',
       model: 'ps5 digital',
       series: 'sonyps5de',
       url: 'https://www.mediamarkt.de/de/product/-2661939.html',

--- a/src/store/model/saturn.ts
+++ b/src/store/model/saturn.ts
@@ -242,6 +242,36 @@ export const Saturn: Store = {
     },
     {
       brand: 'sony',
+      model: 'ps5 console',
+      series: 'sonyps5c',
+      url: 'https://www.saturn.de/de/product/_sony-ps5-ghost-of-tsushima-directors-cut-2757003.html',
+    },
+    {
+      brand: 'sony',
+      model: 'ps5 console',
+      series: 'sonyps5c',
+      url: 'https://www.saturn.de/de/product/_sony-ps5-ratchet-clank-rift-apart-2741441.html',
+    },
+    {
+      brand: 'sony',
+      model: 'ps5 console',
+      series: 'sonyps5c',
+      url: 'https://www.saturn.de/de/product/_sony-playstationr5-deathloop-death-stranding-dc-nur-online-2768018.html',
+    },
+    {
+      brand: 'sony',
+      model: 'ps5 console',
+      series: 'sonyps5c',
+      url: 'https://www.saturn.de/de/product/_sony-playstationr5-death-stranding-directors-cut-nur-online-2765122.html',
+    },
+    {
+      brand: 'sony',
+      model: 'ps5 console',
+      series: 'sonyps5c',
+      url: 'https://www.saturn.de/de/product/_sony-playstationr5-ghost-of-tsushima-death-stranding-dc-nur-online-2768019.html',
+    },
+    {
+      brand: 'sony',
       model: 'ps5 digital',
       series: 'sonyps5de',
       url: 'https://www.saturn.de/de/product/-2661939.html',


### PR DESCRIPTION
### Description

feat: Adds additional bundles to MediaMarkt (DE) & Saturn (DE):

- SONY PS5 + Ghost of Tsushima Director's Cut
- SONY PlayStation®5 + DEATH STRANDING DIRECTORS CUT
- SONY PlayStation®5 + DEATHLOOP + DEATH STRANDING DC
- SONY PS5 + Ratchet & Clank: Rift Apart



