### PR TITLE
fix: amazon prices

### DIFF
--- a/src/store/model/amazon.ts
+++ b/src/store/model/amazon.ts
@@ -33,7 +33,7 @@ export const Amazon: Store = {
       },
     ],
     maxPrice: {
-      container: '#priceblock_ourprice',
+      container: '.a-offscreen',
     },
   },
   links: [


### PR DESCRIPTION
<!-- Please use Conventional Commits to label your title -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/ -->
<!-- Example: feat: allow provided config object to extend other configs  -->

### Description
Amazon US was not pulling prices.

### Testing

Manually tested items are being filtered on Amazon by price