### PR TITLE
fix(puppeteer): cannot read property

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import * as Process from 'process';
 import {config} from './config'; // Needs to be loaded first
 import {startAPIServer, stopAPIServer} from './web';
-import Puppeteer, {Browser} from "puppeteer";
+import Puppeteer, {Browser} from 'puppeteer';
 import {getSleepTime} from './util';
 import {logger} from './logger';
 import {storeList} from './store/model';


### PR DESCRIPTION
Simple code rewrite that fixe "Error cannot read property '_launcher' of undefined" in launching Puppeteer
More info:
https://stackoverflow.com/questions/69494700/puppeteer-launcher-error-results-with-undefined

### Description
Fixes: something bad happened, resetting streetmerchant in 5 seconds Cannot read property '_launcher' of undefined
OS: Windows 10

### Testing
Work on Windows 10 (under VScode terminal)

### New dependencies
none