### PR TITLE
fix: rectify 4090 URLs in newegg.ts

### DIFF
--- a/src/store/model/newegg.ts
+++ b/src/store/model/newegg.ts
@@ -519,8 +519,8 @@ export const Newegg: Store = {
     {
       brand: 'gigabyte',
       cartUrl:
-        'https://secure.newegg.com/Shopping/AddtoCart.aspx?Submit=ADD&ItemList=N82E16814126594',
-      itemNumber: 'N82E16814126596',
+        'https://secure.newegg.com/Shopping/AddtoCart.aspx?Submit=ADD&ItemList=N82E16814932556',
+      itemNumber: 'N82E16814932556',
       model: 'aorus xtreme waterforce 24g',
       series: '4090',
       url: 'https://www.newegg.com/gigabyte-geforce-rtx-4090-gv-n4090aorusx-w-24gd/p/N82E16814932556',
@@ -555,15 +555,6 @@ export const Newegg: Store = {
     {
       brand: 'msi',
       cartUrl:
-        'https://secure.newegg.com/Shopping/AddtoCart.aspx?Submit=ADD&ItemList=N82E16814137762',
-      itemNumber: 'N82E16814137762',
-      model: 'gaming trio',
-      series: '4090',
-      url: 'https://www.newegg.com/msi-geforce-rtx-4090-rtx-4090-gaming-trio-24g/p/N82E16814137762',
-    },
-    {
-      brand: 'msi',
-      cartUrl:
         'https://secure.newegg.com/Shopping/AddtoCart.aspx?Submit=ADD&ItemList=N82E16814137759',
       itemNumber: 'N82E16814137759',
       model: 'suprim',
@@ -582,11 +573,11 @@ export const Newegg: Store = {
     {
       brand: 'asus',
       cartUrl:
-        'https://secure.newegg.com/Shopping/AddtoCart.aspx?Submit=ADD&ItemList=N82E16814126593',
-      itemNumber: 'N82E16814126593',
+        'https://secure.newegg.com/Shopping/AddtoCart.aspx?Submit=ADD&ItemList=N82E16814126600',
+      itemNumber: 'N82E16814126600',
       model: 'strix',
       series: '4090',
-      url: 'https://www.newegg.com/asus-geforce-rtx-4090-rog-strix-rtx4090-o24g-gaming/p/N82E16814126593',
+      url: 'https://www.newegg.com/asus-geforce-rtx-4090-rog-strix-rtx4090-24g-gaming/p/N82E16814126600',
     },
     {
       brand: 'asus',
@@ -594,15 +585,6 @@ export const Newegg: Store = {
         'https://secure.newegg.com/Shopping/AddtoCart.aspx?Submit=ADD&ItemList=N82E16814126593',
       itemNumber: 'N82E16814126593',
       model: 'strix oc',
-      series: '4090',
-      url: 'https://www.newegg.com/asus-geforce-rtx-4090-rog-strix-rtx4090-o24g-gaming/p/N82E16814126593',
-    },
-    {
-      brand: 'asus',
-      cartUrl:
-        'https://secure.newegg.com/Shopping/AddtoCart.aspx?Submit=ADD&ItemList=N82E16814126600',
-      itemNumber: 'N82E16814126600',
-      model: 'strix',
       series: '4090',
       url: 'https://www.newegg.com/asus-geforce-rtx-4090-rog-strix-rtx4090-o24g-gaming/p/N82E16814126593',
     },
@@ -619,7 +601,7 @@ export const Newegg: Store = {
       brand: 'asus',
       cartUrl:
         'https://secure.newegg.com/Shopping/AddtoCart.aspx?Submit=ADD&ItemList=N82E16814126594',
-      itemNumber: 'N82E16814126596',
+      itemNumber: 'N82E16814126594',
       model: 'tuf oc',
       series: '4090',
       url: 'https://www.newegg.com/asus-geforce-rtx-4090-tuf-rtx4090-o24g-gaming/p/N82E16814126594',
@@ -632,24 +614,6 @@ export const Newegg: Store = {
       model: 'trinity',
       series: '4090',
       url: 'https://www.newegg.com/zotac-geforce-rtx-4090-zt-d40900d-10p/p/N82E16814500539',
-    },
-    {
-      brand: 'zotac',
-      cartUrl:
-        'https://secure.newegg.com/Shopping/AddtoCart.aspx?Submit=ADD&ItemList=N82E16814500539',
-      itemNumber: 'N82E16814500539',
-      model: 'trinity',
-      series: '4090',
-      url: 'https://www.newegg.com/zotac-geforce-rtx-4090-zt-d40900d-10p/p/N82E16814500539',
-    },
-    {
-      brand: 'zotac',
-      cartUrl:
-        'https://secure.newegg.com/Shopping/AddtoCart.aspx?Submit=ADD&ItemList=N82E16814500538',
-      itemNumber: 'N82E16814500538',
-      model: 'amp extreme airo',
-      series: '4090',
-      url: 'https://www.newegg.com/zotac-geforce-rtx-4090-zt-d40900b-10p/p/N82E16814500538',
     },
     {
       brand: 'zotac',


### PR DESCRIPTION
Removed redundant entries, and rectified URLs to point to their labeled resource. There were some inconsistencies between the Cart URL and the item number that the product belonged to.

<!-- Please use Conventional Commits to label your title -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/ -->
<!-- Example: feat: allow provided config object to extend other configs  -->

### Description
There are URLs that were inconsistent with the current state of Newegg, or internally pointed at mismatched Item Numbers. I went through and revalidated each one.
<!-- Fixes #(issue) -->
<!-- Please also include relevant motivation and context. -->

### Testing
I tested each URL in browser and just ensured that the item numbers line up with their respective labels.
<!-- Please describe the tests that you ran to verify your changes. -->
<!-- Provide instructions so we can reproduce. -->
<!-- Please also list any relevant details for your test configuration -->
