### PR TITLE
fix:  Corrected label for newegg asus astral 5080

### DIFF
--- a/src/store/model/newegg.ts
+++ b/src/store/model/newegg.ts
@@ -1803,7 +1803,7 @@ export const Newegg: Store = {
       cartUrl:
         'https://secure.newegg.com/Shopping/AddtoCart.aspx?Submit=ADD&ItemList=N82E16814126742',
       model: 'astral oc',
-      series: '5090',
+      series: '5080',
       url: 'https://www.newegg.com/p/N82E16814126742',
     },
   ],


### PR DESCRIPTION

### Description

Fixed mislableld link in store model, it was labeled as a 5090 when it is a link to 5080.
I got a false positive where it alerted to a newegg 5080 astral when i only wanted 5090
### Testing

Ran against 5090 targeted scanning, worked as expected.

