### PR TITLE
fix: update selector for newegg product price

### DIFF
--- a/src/store/model/newegg.ts
+++ b/src/store/model/newegg.ts
@@ -19,12 +19,12 @@ export const Newegg: Store = {
       },
     ],
     maxPrice: {
-      container: '.price-current',
+      container: '.product-pane .price-current',
     },
     outOfStock: [
       {
-        container: '.product-inventory',
-        text: [' out of stock.'],
+        container: '.product-buy',
+        text: ['out of stock'],
       },
       {
         container: '.product-flag',


### PR DESCRIPTION
<!-- Please use Conventional Commits to label your title -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/ -->
<!-- Example: feat: allow provided config object to extend other configs  -->

### Description

Currently, the MAX_PRICE_* feature doesn't work with Newegg, because it's using the wrong selector. This change updates the selector so that the product price is correctly selected. I've also changed the `outOfStock` selector to `.product-buy` because `.product-inventory` does not exist on the product page.

<!-- Fixes #(issue) -->
<!-- Please also include relevant motivation and context. -->

### Testing

- I tested the Out of Stock functionality and works as it should.
- To test the max price feature, I manually changed a product link in the Newegg store that was in stock and set a MAX_PRICE. I've verified the notification is ignored if the product is over the max set. 

<!-- Please describe the tests that you ran to verify your changes. -->
<!-- Provide instructions so we can reproduce. -->
<!-- Please also list any relevant details for your test configuration -->

### New dependencies

<!-- List any dependencies that are required for this change. -->
<!-- Otherwise, delete section. -->
